### PR TITLE
Fix ProductResponse missing Description and Price fields

### DIFF
--- a/domain/Ecommerce.Model/Product/Response/ProductResponse.cs
+++ b/domain/Ecommerce.Model/Product/Response/ProductResponse.cs
@@ -4,5 +4,7 @@ namespace Ecommerce.Model.Product.Response
     {
         public long Key { get; set; }
         public string Name { get; set; }
+        public string Description { get; set; }
+        public decimal Price { get; set; }
     }
 }

--- a/product-service/Product.Infrastructure/MongoProductRepository.cs
+++ b/product-service/Product.Infrastructure/MongoProductRepository.cs
@@ -20,7 +20,7 @@ namespace Product.Infrastructure
 
         public async Task<ProductDto> Create(ProductDto product)
         {
-            var mp = new MongoProductDto { Name = product.Name, Key = await GetNextId() };
+            var mp = new MongoProductDto { Name = product.Name, Description = product.Description, Price = product.Price, Key = await GetNextId() };
             await products.InsertOneAsync(mp);
 
             return mp;


### PR DESCRIPTION
## Summary
- Add `Description` and `Price` properties to `ProductResponse` so API consumers can retrieve these fields
- Fix `MongoProductRepository.Create` to persist `Description` and `Price` (previously silently dropped)

## Test plan
- [x] `dotnet build --configuration Release` succeeds with 0 warnings, 0 errors
- [ ] POST a product with Description/Price, then GET it and verify both fields are returned

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)