### PR TITLE
Add pagination, sorting and filtering to GET products

### DIFF
--- a/domain/Ecommerce.Model/PagedResponse.cs
+++ b/domain/Ecommerce.Model/PagedResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Ecommerce.Model
+{
+    public class PagedResponse<T>
+    {
+        public IEnumerable<T> Items { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+        public int TotalCount { get; set; }
+        public int TotalPages { get; set; }
+    }
+}

--- a/product-service/Product.Application/Queries/GetProductsQuery.cs
+++ b/product-service/Product.Application/Queries/GetProductsQuery.cs
@@ -1,18 +1,25 @@
 using AutoMapper;
+using Ecommerce.Model;
 using Ecommerce.Model.Product.Response;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
+using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Product.Application.Queries
 {
-    public class GetProductsQuery : IRequest<IEnumerable<ProductResponse>>
+    public class GetProductsQuery : IRequest<PagedResponse<ProductResponse>>
     {
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+        public string SortBy { get; set; }
+        public string SortDirection { get; set; } = "asc";
+        public string Search { get; set; }
     }
 
-    public class GetProductsQueryHandler : IRequestHandler<GetProductsQuery, IEnumerable<ProductResponse>>
+    public class GetProductsQueryHandler : IRequestHandler<GetProductsQuery, PagedResponse<ProductResponse>>
     {
         private readonly ProductDbContext _dbContext;
         private readonly IMapper _mapper;
@@ -23,11 +30,46 @@ namespace Product.Application.Queries
             _mapper = mapper;
         }
 
-        public async Task<IEnumerable<ProductResponse>> Handle(GetProductsQuery request, CancellationToken cancellationToken)
+        public async Task<PagedResponse<ProductResponse>> Handle(GetProductsQuery request, CancellationToken cancellationToken)
         {
-            var products = await _dbContext.Products.AsNoTracking().ToListAsync(cancellationToken);
+            var page = Math.Max(1, request.Page);
+            var pageSize = Math.Clamp(request.PageSize, 1, 100);
 
-            return _mapper.Map<IEnumerable<ProductResponse>>(products);
+            var query = _dbContext.Products.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(request.Search))
+            {
+                var search = request.Search.ToLower();
+                query = query.Where(p => p.Name.ToLower().Contains(search));
+            }
+
+            query = request.SortBy?.ToLower() switch
+            {
+                "name" => request.SortDirection?.ToLower() == "desc"
+                    ? query.OrderByDescending(p => p.Name)
+                    : query.OrderBy(p => p.Name),
+                "price" => request.SortDirection?.ToLower() == "desc"
+                    ? query.OrderByDescending(p => p.Price)
+                    : query.OrderBy(p => p.Price),
+                _ => request.SortDirection?.ToLower() == "desc"
+                    ? query.OrderByDescending(p => p.Id)
+                    : query.OrderBy(p => p.Id)
+            };
+
+            var totalCount = await query.CountAsync(cancellationToken);
+            var products = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PagedResponse<ProductResponse>
+            {
+                Items = _mapper.Map<ProductResponse[]>(products),
+                Page = page,
+                PageSize = pageSize,
+                TotalCount = totalCount,
+                TotalPages = (int)Math.Ceiling((double)totalCount / pageSize)
+            };
         }
     }
 }

--- a/product-service/Product.Service/Controllers/ProductController.cs
+++ b/product-service/Product.Service/Controllers/ProductController.cs
@@ -1,3 +1,4 @@
+using Ecommerce.Model;
 using Ecommerce.Model.Product.Request;
 using Ecommerce.Model.Product.Response;
 using MediatR;
@@ -5,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Product.Application.Commands;
 using Product.Application.Queries;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Product.Service.Controllers
@@ -24,10 +24,22 @@ namespace Product.Service.Controllers
         }
 
         [HttpGet]
-        [ProducesResponseType(200, Type = typeof(IEnumerable<ProductResponse>))]
-        public async Task<IActionResult> GetProducts()
+        [ProducesResponseType(200, Type = typeof(PagedResponse<ProductResponse>))]
+        public async Task<IActionResult> GetProducts(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20,
+            [FromQuery] string sortBy = null,
+            [FromQuery] string sortDirection = "asc",
+            [FromQuery] string search = null)
         {
-            var products = await _mediator.Send(new GetProductsQuery());
+            var products = await _mediator.Send(new GetProductsQuery
+            {
+                Page = page,
+                PageSize = pageSize,
+                SortBy = sortBy,
+                SortDirection = sortDirection,
+                Search = search
+            });
 
             return Ok(products);
         }


### PR DESCRIPTION
## Summary
- `GET /product` now returns a paged response with query parameters for pagination, sorting, and search
- Add shared `PagedResponse<T>` in `Ecommerce.Model` for reuse across future services
- Search filters by product name (case-insensitive `LIKE`)
- Sort by `name`, `price`, or `id` (default), ascending or descending
- Page size clamped to 1–100

## Query Parameters
| Parameter | Default | Description |
|-----------|---------|-------------|
| `page` | 1 | Page number |
| `pageSize` | 20 | Items per page (max 100) |
| `sortBy` | `id` | Sort field: `id`, `name`, `price` |
| `sortDirection` | `asc` | `asc` or `desc` |
| `search` | — | Filter by product name |

## Example
```
GET /product?page=2&pageSize=10&sortBy=price&sortDirection=desc&search=apple
```

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [ ] GET without params returns first 20 products with pagination metadata
- [ ] GET with search filters correctly
- [ ] GET with sort orders correctly
- [ ] GET with page/pageSize paginates correctly

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)