### PR TITLE
Add request validation with FluentValidation

### DIFF
--- a/product-service/Product.Application/Validators/CreateProductCommandValidator.cs
+++ b/product-service/Product.Application/Validators/CreateProductCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using Product.Application.Commands;
+
+namespace Product.Application.Validators;
+
+public class CreateProductCommandValidator : AbstractValidator<CreateProductCommand>
+{
+    public CreateProductCommandValidator()
+    {
+        RuleFor(x => x.Request.Name)
+            .NotEmpty().WithMessage("Name is required")
+            .MaximumLength(200).WithMessage("Name must not exceed 200 characters");
+
+        RuleFor(x => x.Request.Price)
+            .GreaterThan(0).WithMessage("Price must be greater than 0");
+
+        RuleFor(x => x.Request.Description)
+            .MaximumLength(2000).WithMessage("Description must not exceed 2000 characters");
+    }
+}

--- a/product-service/Product.Application/Validators/UpdateProductCommandValidator.cs
+++ b/product-service/Product.Application/Validators/UpdateProductCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using Product.Application.Commands;
+
+namespace Product.Application.Validators;
+
+public class UpdateProductCommandValidator : AbstractValidator<UpdateProductCommand>
+{
+    public UpdateProductCommandValidator()
+    {
+        RuleFor(x => x.Request.Name)
+            .NotEmpty().WithMessage("Name is required")
+            .MaximumLength(200).WithMessage("Name must not exceed 200 characters");
+
+        RuleFor(x => x.Request.Price)
+            .GreaterThan(0).WithMessage("Price must be greater than 0");
+
+        RuleFor(x => x.Request.Description)
+            .MaximumLength(2000).WithMessage("Description must not exceed 2000 characters");
+    }
+}

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -1,4 +1,6 @@
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Validation;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using Product.Application;
@@ -9,8 +11,16 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.RegisterInfrastructure(builder.Configuration);
 builder.Services.AddSharedInfrastructure(builder.Configuration);
-builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateProductCommand).Assembly));
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(CreateProductCommand).Assembly);
+    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
+});
+builder.Services.AddValidatorsFromAssembly(typeof(CreateProductCommand).Assembly);
 builder.Services.AddAutoMapper(typeof(MapperProfile).Assembly);
+
+builder.Services.AddExceptionHandler<ValidationExceptionHandler>();
+builder.Services.AddProblemDetails();
 
 builder.Services.AddControllers();
 builder.Services.AddSwaggerGen(c =>
@@ -33,6 +43,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Product.Service v1"));
 }
 
+app.UseExceptionHandler();
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();

--- a/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
+++ b/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
@@ -5,7 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.5" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationBehavior.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationBehavior.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+using MediatR;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ecommerce.Shared.Infrastructure.Validation;
+
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+            return await next();
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationResults = await Task.WhenAll(
+            _validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        var errors = validationResults
+            .SelectMany(r => r.Errors)
+            .Where(f => f != null)
+            .GroupBy(f => f.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(f => f.ErrorMessage).ToArray());
+
+        if (errors.Count > 0)
+            throw new ValidationException(errors);
+
+        return await next();
+    }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationException.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationException.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ecommerce.Shared.Infrastructure.Validation;
+
+public class ValidationException : Exception
+{
+    public IDictionary<string, string[]> Errors { get; }
+
+    public ValidationException(IDictionary<string, string[]> errors)
+        : base("One or more validation errors occurred.")
+    {
+        Errors = errors;
+    }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationExceptionHandler.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Validation/ValidationExceptionHandler.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ecommerce.Shared.Infrastructure.Validation;
+
+public class ValidationExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, System.Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not ValidationException validationException)
+            return false;
+
+        var problemDetails = new ValidationProblemDetails(validationException.Errors)
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Validation Failed"
+        };
+
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add automatic request validation using **FluentValidation** with a **MediatR pipeline behavior**
- Validation runs before handlers execute — invalid requests never reach business logic
- Returns standardised `400 ValidationProblemDetails` responses via `IExceptionHandler`

## Shared Infrastructure (reusable by all services)
- `ValidationBehavior<TRequest, TResponse>` — MediatR `IPipelineBehavior` that runs all registered validators
- `ValidationException` — contains field-level error dictionary
- `ValidationExceptionHandler` — `IExceptionHandler` returning RFC 7807 problem details

## Validation Rules
| Field | Rule |
|-------|------|
| `Name` | Required, max 200 characters |
| `Price` | Must be greater than 0 |
| `Description` | Max 2000 characters |

## Example Error Response
```json
{
  "title": "Validation Failed",
  "status": 400,
  "errors": {
    "Request.Name": ["Name is required"],
    "Request.Price": ["Price must be greater than 0"]
  }
}
```

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [ ] POST product with empty name returns 400 with error details
- [ ] POST product with negative price returns 400
- [ ] POST product with valid data succeeds as before

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)