### PR TITLE
Add Docker health checks to all application services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,12 @@ services:
       - RabbitMq__Host=rabbitmq
       - Serilog__WriteTo__1__Name=Seq
       - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - ecommerce-network
     depends_on:
@@ -81,12 +87,22 @@ services:
       - RabbitMq__Host=rabbitmq
       - Serilog__WriteTo__1__Name=Seq
       - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - ecommerce-network
     depends_on:
       postgres:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      product:
+        condition: service_healthy
+      stock:
         condition: service_healthy
 
   stock:
@@ -101,6 +117,12 @@ services:
       - RabbitMq__Host=rabbitmq
       - Serilog__WriteTo__1__Name=Seq
       - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - ecommerce-network
     depends_on:
@@ -124,6 +146,12 @@ services:
       - JwtSettings__Audience=ecommerce
       - Serilog__WriteTo__1__Name=Seq
       - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - ecommerce-network
     depends_on:
@@ -145,6 +173,12 @@ services:
       - StripeSettings__SecretKey=${STRIPE_SECRET_KEY:-}
       - Serilog__WriteTo__1__Name=Seq
       - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - ecommerce-network
     depends_on:


### PR DESCRIPTION
## Summary
- Add `healthcheck` configuration to all 5 application services (product, order, stock, user, payment)
- Use `wget` to hit each service's `/health` endpoint (available in the aspnet:8.0 Debian base image)
- Configure appropriate intervals: 30s interval, 10s timeout, 3 retries, 30s start period
- Add cross-service `depends_on` with `condition: service_healthy` — order now waits for product and stock to be healthy

## Test plan
- [ ] Run `docker compose --profile app up -d` and verify all services show health status
- [ ] Run `docker compose ps` and confirm "healthy" status for all app services
- [ ] Verify order service starts only after product and stock are healthy
- [ ] Simulate an unhealthy service and confirm it's detected

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)