### PR TITLE
Add database connection pooling with PgBouncer

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,9 @@
       "Bash(dotnet build:*)",
       "Bash(git commit:*)",
       "Bash(gh pr:*)",
-      "Bash(dotnet ef migrations add:*)"
+      "Bash(dotnet ef migrations add:*)",
+      "Bash(cd /c/Users/lewis/src/ecommerce && docker compose config --quiet 2>&1 && echo \"Valid\" && git add docker-compose.yml && git rebase --continue 2>&1)",
+      "Bash(cd /c/Users/lewis/src/ecommerce && git add -A && GIT_EDITOR=true git rebase --continue 2>&1)"
     ]
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,24 @@ services:
     networks:
       - ecommerce-network
 
+  pgbouncer:
+    image: edoburu/pgbouncer:1.23.1-p2
+    ports:
+      - "6432:6432"
+    volumes:
+      - ./scripts/pgbouncer/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
+      - ./scripts/pgbouncer/userlist.txt:/etc/pgbouncer/userlist.txt:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 6432 -U ecommerce -d product_db || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - ecommerce-network
+
   rabbitmq:
     image: rabbitmq:3-management
     ports:
@@ -77,12 +95,12 @@ services:
       - "5001:8080"
     env_file: .env.docker
     environment:
-      - ConnectionStrings__ProductDb=Host=postgres;Database=product_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__ProductDb=Host=pgbouncer;Port=6432;Database=product_db;Username=ecommerce;Password=ecommerce
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
@@ -96,12 +114,12 @@ services:
       - "5002:8080"
     env_file: .env.docker
     environment:
-      - ConnectionStrings__OrderDb=Host=postgres;Database=order_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__OrderDb=Host=pgbouncer;Port=6432;Database=order_db;Username=ecommerce;Password=ecommerce
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
@@ -119,12 +137,12 @@ services:
       - "5003:8080"
     env_file: .env.docker
     environment:
-      - ConnectionStrings__StockDb=Host=postgres;Database=stock_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__StockDb=Host=pgbouncer;Port=6432;Database=stock_db;Username=ecommerce;Password=ecommerce
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
@@ -138,12 +156,12 @@ services:
       - "5004:8080"
     env_file: .env.docker
     environment:
-      - ConnectionStrings__UserDb=Host=postgres;Database=user_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__UserDb=Host=pgbouncer;Port=6432;Database=user_db;Username=ecommerce;Password=ecommerce
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
@@ -157,13 +175,13 @@ services:
       - "5005:8080"
     env_file: .env.docker
     environment:
-      - ConnectionStrings__PaymentDb=Host=postgres;Database=payment_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__PaymentDb=Host=pgbouncer;Port=6432;Database=payment_db;Username=ecommerce;Password=ecommerce
       - StripeSettings__SecretKey=${STRIPE_SECRET_KEY:-}
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy

--- a/scripts/pgbouncer/pgbouncer.ini
+++ b/scripts/pgbouncer/pgbouncer.ini
@@ -1,0 +1,22 @@
+[databases]
+product_db = host=postgres port=5432 dbname=product_db
+order_db = host=postgres port=5432 dbname=order_db
+stock_db = host=postgres port=5432 dbname=stock_db
+user_db = host=postgres port=5432 dbname=user_db
+payment_db = host=postgres port=5432 dbname=payment_db
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = md5
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = transaction
+default_pool_size = 20
+min_pool_size = 5
+max_client_conn = 200
+max_db_connections = 50
+server_idle_timeout = 300
+log_connections = 1
+log_disconnections = 1
+stats_period = 60
+admin_users = ecommerce

--- a/scripts/pgbouncer/userlist.txt
+++ b/scripts/pgbouncer/userlist.txt
@@ -1,0 +1,1 @@
+"ecommerce" "md551a48abda0f93ff554bfccbcc22f1435"


### PR DESCRIPTION
## Summary
- Add PgBouncer as a connection pooler between app services and PostgreSQL
- **Transaction-level pooling** — connections are returned to the pool after each transaction
- Pool config: 20 default pool size, 200 max client connections, 50 max DB connections
- All 5 database-backed services now route through `pgbouncer:6432` instead of `postgres:5432`
- PgBouncer depends on postgres being healthy; app services depend on pgbouncer being healthy
- Admin console accessible for monitoring pool stats
- Postgres still directly accessible on port 5432 for migrations and admin tasks

## Test plan
- [ ] Run `docker compose --profile app up -d` and verify all services connect through PgBouncer
- [ ] Check PgBouncer stats: `docker compose exec pgbouncer psql -p 6432 -U ecommerce pgbouncer -c "SHOW POOLS;"`
- [ ] Verify connection count to Postgres stays bounded (check with `SELECT count(*) FROM pg_stat_activity;`)
- [ ] Run existing API tests and verify all functionality works through the pooler
- [ ] Verify health checks pass through PgBouncer

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)