### PR TITLE
Add gRPC for inter-service communication

### DIFF
--- a/Ecommerce.sln
+++ b/Ecommerce.sln
@@ -79,6 +79,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cart.Service", "cart-servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cart.Application.Tests", "cart-service\Cart.Application.Tests\Cart.Application.Tests.csproj", "{62220B06-F461-477B-ACD3-7FAC46D26143}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ecommerce.Shared.Protos", "shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj", "{702886C9-7EDB-4C71-9C37-105438204E34}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ecommerce.Shared.GrpcClients", "shared\Ecommerce.Shared.GrpcClients\Ecommerce.Shared.GrpcClients.csproj", "{2E40D078-506F-4679-B0AF-FF4F42511504}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -437,6 +441,30 @@ Global
 		{62220B06-F461-477B-ACD3-7FAC46D26143}.Release|x64.Build.0 = Release|Any CPU
 		{62220B06-F461-477B-ACD3-7FAC46D26143}.Release|x86.ActiveCfg = Release|Any CPU
 		{62220B06-F461-477B-ACD3-7FAC46D26143}.Release|x86.Build.0 = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|x64.Build.0 = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Debug|x86.Build.0 = Debug|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|x64.ActiveCfg = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|x64.Build.0 = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|x86.ActiveCfg = Release|Any CPU
+		{702886C9-7EDB-4C71-9C37-105438204E34}.Release|x86.Build.0 = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|x64.Build.0 = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E40D078-506F-4679-B0AF-FF4F42511504}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -471,6 +499,8 @@ Global
 		{D3A8EFD8-A470-4D24-95B0-C534F2406EC4} = {245AC2C2-169F-7439-7A17-46DCAF344A17}
 		{23F6C82B-C89E-4051-AD0C-FD2EE6EFE9C3} = {245AC2C2-169F-7439-7A17-46DCAF344A17}
 		{62220B06-F461-477B-ACD3-7FAC46D26143} = {245AC2C2-169F-7439-7A17-46DCAF344A17}
+		{702886C9-7EDB-4C71-9C37-105438204E34} = {15FF4A91-B3F4-410F-9317-CC23EDF60D0F}
+		{2E40D078-506F-4679-B0AF-FF4F42511504} = {15FF4A91-B3F4-410F-9317-CC23EDF60D0F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FE3BEF9D-AF6C-4272-863D-F91D8916A0C6}

--- a/cart-service/Cart.Infrastructure/Cart.Infrastructure.csproj
+++ b/cart-service/Cart.Infrastructure/Cart.Infrastructure.csproj
@@ -7,12 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Cart.Application\Cart.Application.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
   </ItemGroup>
 
 </Project>

--- a/cart-service/Cart.Infrastructure/DependencyInjection.cs
+++ b/cart-service/Cart.Infrastructure/DependencyInjection.cs
@@ -18,12 +18,7 @@ public static class DependencyInjection
         });
 
         services.AddScoped<ICartRepository, RedisCartRepository>();
-
-        services.AddHttpClient<IProductCatalogClient, ProductCatalogClient>(client =>
-        {
-            var baseUrl = configuration["ProductService:BaseUrl"] ?? "http://product:8080";
-            client.BaseAddress = new Uri(baseUrl);
-        });
+        services.AddScoped<IProductCatalogClient, ProductCatalogClient>();
 
         return services;
     }

--- a/cart-service/Cart.Infrastructure/ProductCatalogClient.cs
+++ b/cart-service/Cart.Infrastructure/ProductCatalogClient.cs
@@ -1,27 +1,31 @@
-using System.Net.Http.Json;
-using System.Text.Json;
 using Cart.Application.Interfaces;
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
 
 namespace Cart.Infrastructure;
 
 public class ProductCatalogClient : IProductCatalogClient
 {
-    private readonly HttpClient _httpClient;
-    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private readonly ProductGrpc.ProductGrpcClient _grpcClient;
 
-    public ProductCatalogClient(HttpClient httpClient)
+    public ProductCatalogClient(ProductGrpc.ProductGrpcClient grpcClient)
     {
-        _httpClient = httpClient;
+        _grpcClient = grpcClient;
     }
 
     public async Task<ProductInfo?> GetProductAsync(long productId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"/product/{productId}", cancellationToken);
-        if (!response.IsSuccessStatusCode) return null;
+        try
+        {
+            var reply = await _grpcClient.GetProductAsync(
+                new GetProductRequest { Id = productId },
+                cancellationToken: cancellationToken);
 
-        var product = await response.Content.ReadFromJsonAsync<ProductResponse>(JsonOptions, cancellationToken);
-        return product is null ? null : new ProductInfo(product.Id, product.Name, product.Price);
+            return new ProductInfo(reply.Id, reply.Name, decimal.Parse(reply.Price));
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            return null;
+        }
     }
-
-    private record ProductResponse(long Id, string Name, decimal Price);
 }

--- a/cart-service/Cart.Service/Cart.Service.csproj
+++ b/cart-service/Cart.Service/Cart.Service.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Cart.Infrastructure\Cart.Infrastructure.csproj" />
     <ProjectReference Include="..\..\shared\Ecommerce.Shared.Infrastructure\Ecommerce.Shared.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.GrpcClients\Ecommerce.Shared.GrpcClients.csproj" />
   </ItemGroup>
 
 </Project>

--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -1,6 +1,8 @@
 using Cart.Application.Commands;
 using Cart.Application.Mappings;
 using Cart.Infrastructure;
+using Cart.Service.Services;
+using Ecommerce.Shared.GrpcClients;
 using Ecommerce.Shared.Infrastructure;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
@@ -42,6 +44,8 @@ try
     builder.Services.AddHealthChecks()
         .AddRedis(builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379", name: "redis");
 
+    builder.Services.AddGrpc();
+    builder.Services.AddProductGrpcClient(builder.Configuration);
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -63,6 +67,7 @@ try
 
     app.UseHttpsRedirection();
     app.UseAuthorization();
+    app.MapGrpcService<CartGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/cart-service/Cart.Service/Services/CartGrpcService.cs
+++ b/cart-service/Cart.Service/Services/CartGrpcService.cs
@@ -1,0 +1,45 @@
+using Cart.Application.Queries;
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+
+namespace Cart.Service.Services;
+
+public class CartGrpcService : CartGrpc.CartGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public CartGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<CartReply> GetCart(GetCartRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetCartQuery(request.CartId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Cart {request.CartId} not found"));
+
+        var reply = new CartReply
+        {
+            Id = result.Id,
+            TotalPrice = result.TotalPrice.ToString(),
+            LastModifiedAt = result.LastModifiedAt.ToString("O")
+        };
+
+        foreach (var item in result.Items)
+        {
+            reply.Items.Add(new CartItemReply
+            {
+                ProductId = item.ProductId,
+                ProductName = item.ProductName ?? string.Empty,
+                Quantity = item.Quantity,
+                UnitPrice = item.UnitPrice.ToString(),
+                LineTotal = item.LineTotal.ToString()
+            });
+        }
+
+        return reply;
+    }
+}

--- a/cart-service/Dockerfile
+++ b/cart-service/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /src
 
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
+COPY shared/Ecommerce.Shared.GrpcClients/Ecommerce.Shared.GrpcClients.csproj shared/Ecommerce.Shared.GrpcClients/
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY cart-service/Cart.Application/Cart.Application.csproj cart-service/Cart.Application/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__OrderDb=Host=pgbouncer;Port=6432;Database=order_db;Username=ecommerce;Password=ecommerce
+      - GrpcClients__ProductService=http://product:8080
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -196,7 +197,7 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__Redis=redis:6379
-      - ProductService__BaseUrl=http://product:8080
+      - GrpcClients__ProductService=http://product:8080
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /src
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
+COPY shared/Ecommerce.Shared.GrpcClients/Ecommerce.Shared.GrpcClients.csproj shared/Ecommerce.Shared.GrpcClients/
 COPY order-service/Order.Application/Order.Application.csproj order-service/Order.Application/
 COPY order-service/Order.Infrastructure/Order.Infrastructure.csproj order-service/Order.Infrastructure/
 COPY order-service/Order.Service/Order.Service.csproj order-service/Order.Service/

--- a/order-service/Order.Service/Order.Service.csproj
+++ b/order-service/Order.Service/Order.Service.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.GrpcClients\Ecommerce.Shared.GrpcClients.csproj" />
     <ProjectReference Include="..\Order.Infrastructure\Order.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -1,3 +1,4 @@
+using Ecommerce.Shared.GrpcClients;
 using Ecommerce.Shared.Infrastructure;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
@@ -10,6 +11,7 @@ using Order.Application.Commands;
 using Order.Application.Entities;
 using Order.Application.Saga;
 using Order.Infrastructure;
+using Order.Service.Services;
 using Serilog;
 
 Log.Logger = new LoggerConfiguration()
@@ -59,6 +61,8 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("OrderDb")!, name: "postgresql");
 
+    builder.Services.AddGrpc();
+    builder.Services.AddProductGrpcClient(builder.Configuration);
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -87,6 +91,7 @@ try
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
     app.UseAuthorization();
+    app.MapGrpcService<OrderGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/order-service/Order.Service/Services/OrderGrpcService.cs
+++ b/order-service/Order.Service/Services/OrderGrpcService.cs
@@ -1,0 +1,38 @@
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+using Order.Application.Queries;
+
+namespace Order.Service.Services;
+
+public class OrderGrpcService : OrderGrpc.OrderGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public OrderGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<OrderReply> GetOrder(GetOrderRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.OrderId, out var orderId))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid order ID format"));
+
+        var result = await _mediator.Send(new GetOrderQuery(orderId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Order {request.OrderId} not found"));
+
+        return new OrderReply
+        {
+            OrderId = result.OrderId.ToString(),
+            CustomerId = result.CustomerId ?? string.Empty,
+            Status = result.Status ?? string.Empty,
+            TotalAmount = result.TotalAmount.ToString(),
+            ItemsJson = result.ItemsJson ?? string.Empty,
+            CreatedAt = result.CreatedAt.ToString("O"),
+            UpdatedAt = result.UpdatedAt?.ToString("O") ?? string.Empty
+        };
+    }
+}

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
 COPY payment-service/Payment.Application/Payment.Application.csproj payment-service/Payment.Application/
 COPY payment-service/Payment.Infrastructure/Payment.Infrastructure.csproj payment-service/Payment.Infrastructure/
 COPY payment-service/Payment.Service/Payment.Service.csproj payment-service/Payment.Service/

--- a/payment-service/Payment.Service/Payment.Service.csproj
+++ b/payment-service/Payment.Service/Payment.Service.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
     <ProjectReference Include="..\Payment.Infrastructure\Payment.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -9,6 +9,7 @@ using Payment.Application.Commands;
 using Payment.Application.Consumers;
 using Payment.Application.Services;
 using Payment.Infrastructure;
+using Payment.Service.Services;
 using Serilog;
 using Stripe;
 
@@ -56,6 +57,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("PaymentDb")!, name: "postgresql");
 
+    builder.Services.AddGrpc();
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -84,6 +86,7 @@ try
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
     app.UseAuthorization();
+    app.MapGrpcService<PaymentGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/payment-service/Payment.Service/Services/PaymentGrpcService.cs
+++ b/payment-service/Payment.Service/Services/PaymentGrpcService.cs
@@ -1,0 +1,62 @@
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+using Payment.Application.Queries;
+
+namespace Payment.Service.Services;
+
+public class PaymentGrpcService : PaymentGrpc.PaymentGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public PaymentGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<PaymentReply> GetPaymentByOrder(GetPaymentByOrderRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.OrderId, out var orderId))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid order ID format"));
+
+        var result = await _mediator.Send(new GetPaymentByOrderQuery(orderId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Payment for order {request.OrderId} not found"));
+
+        return new PaymentReply
+        {
+            Id = result.Id,
+            OrderId = result.OrderId.ToString(),
+            CustomerId = result.CustomerId ?? string.Empty,
+            Amount = result.Amount.ToString(),
+            Currency = result.Currency ?? string.Empty,
+            Status = result.Status ?? string.Empty,
+            StripePaymentIntentId = result.StripePaymentIntentId ?? string.Empty,
+            CreatedAt = result.CreatedAt.ToString("O")
+        };
+    }
+
+    public override async Task<GetPaymentsByCustomerReply> GetPaymentsByCustomer(GetPaymentsByCustomerRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetPaymentsByCustomerQuery(request.CustomerId), context.CancellationToken);
+
+        var reply = new GetPaymentsByCustomerReply();
+        foreach (var p in result)
+        {
+            reply.Payments.Add(new PaymentReply
+            {
+                Id = p.Id,
+                OrderId = p.OrderId.ToString(),
+                CustomerId = p.CustomerId ?? string.Empty,
+                Amount = p.Amount.ToString(),
+                Currency = p.Currency ?? string.Empty,
+                Status = p.Status ?? string.Empty,
+                StripePaymentIntentId = p.StripePaymentIntentId ?? string.Empty,
+                CreatedAt = p.CreatedAt.ToString("O")
+            });
+        }
+
+        return reply;
+    }
+}

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
 COPY product-service/Product.Application/Product.Application.csproj product-service/Product.Application/
 COPY product-service/Product.Infrastructure/Product.Infrastructure.csproj product-service/Product.Infrastructure/
 COPY product-service/Product.Service/Product.Service.csproj product-service/Product.Service/

--- a/product-service/Product.Service/Product.Service.csproj
+++ b/product-service/Product.Service/Product.Service.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
     <ProjectReference Include="..\Product.Infrastructure\Product.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.OpenApi.Models;
 using Product.Application;
 using Product.Application.Commands;
 using Product.Infrastructure;
+using Product.Service.Services;
 using Serilog;
 
 Log.Logger = new LoggerConfiguration()
@@ -44,6 +45,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("ProductDb")!, name: "postgresql");
 
+    builder.Services.AddGrpc();
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -72,6 +74,7 @@ try
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
     app.UseAuthorization();
+    app.MapGrpcService<ProductGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/product-service/Product.Service/Services/ProductGrpcService.cs
+++ b/product-service/Product.Service/Services/ProductGrpcService.cs
@@ -1,0 +1,63 @@
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+using Product.Application.Queries;
+
+namespace Product.Service.Services;
+
+public class ProductGrpcService : ProductGrpc.ProductGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public ProductGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<ProductReply> GetProduct(GetProductRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetProductQuery(request.Id), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Product {request.Id} not found"));
+
+        return new ProductReply
+        {
+            Id = result.Id,
+            Name = result.Name ?? string.Empty,
+            Description = result.Description ?? string.Empty,
+            Category = result.Category ?? string.Empty,
+            Price = result.Price.ToString()
+        };
+    }
+
+    public override async Task<GetProductsReply> GetProducts(GetProductsRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetProductsQuery
+        {
+            Page = request.Page,
+            PageSize = request.PageSize
+        }, context.CancellationToken);
+
+        var reply = new GetProductsReply
+        {
+            TotalCount = result.TotalCount,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+
+        foreach (var p in result.Items)
+        {
+            reply.Products.Add(new ProductReply
+            {
+                Id = p.Id,
+                Name = p.Name ?? string.Empty,
+                Description = p.Description ?? string.Empty,
+                Category = p.Category ?? string.Empty,
+                Price = p.Price.ToString()
+            });
+        }
+
+        return reply;
+    }
+}

--- a/shared/Ecommerce.Shared.GrpcClients/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.GrpcClients/DependencyInjection.cs
@@ -1,0 +1,86 @@
+using Ecommerce.Shared.Protos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ecommerce.Shared.GrpcClients;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddProductGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:ProductService"] ?? "http://product:8080";
+
+        services.AddGrpcClient<ProductGrpc.ProductGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddOrderGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:OrderService"] ?? "http://order:8080";
+
+        services.AddGrpcClient<OrderGrpc.OrderGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddStockGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:StockService"] ?? "http://stock:8080";
+
+        services.AddGrpcClient<StockGrpc.StockGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddUserGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:UserService"] ?? "http://user:8080";
+
+        services.AddGrpcClient<UserGrpc.UserGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddPaymentGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:PaymentService"] ?? "http://payment:8080";
+
+        services.AddGrpcClient<PaymentGrpc.PaymentGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddCartGrpcClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        var address = configuration["GrpcClients:CartService"] ?? "http://cart:8080";
+
+        services.AddGrpcClient<CartGrpc.CartGrpcClient>(o =>
+        {
+            o.Address = new Uri(address);
+        });
+
+        return services;
+    }
+}

--- a/shared/Ecommerce.Shared.GrpcClients/Ecommerce.Shared.GrpcClients.csproj
+++ b/shared/Ecommerce.Shared.GrpcClients/Ecommerce.Shared.GrpcClients.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj
+++ b/shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\*.proto" GrpcServices="Both" />
+  </ItemGroup>
+
+</Project>

--- a/shared/Ecommerce.Shared.Protos/Protos/cart.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/cart.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.cart;
+
+service CartGrpc {
+  rpc GetCart (GetCartRequest) returns (CartReply);
+}
+
+message GetCartRequest {
+  string cart_id = 1;
+}
+
+message CartItemReply {
+  int64 product_id = 1;
+  string product_name = 2;
+  int32 quantity = 3;
+  string unit_price = 4;
+  string line_total = 5;
+}
+
+message CartReply {
+  string id = 1;
+  repeated CartItemReply items = 2;
+  string total_price = 3;
+  string last_modified_at = 4;
+}

--- a/shared/Ecommerce.Shared.Protos/Protos/order.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/order.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.order;
+
+service OrderGrpc {
+  rpc GetOrder (GetOrderRequest) returns (OrderReply);
+}
+
+message GetOrderRequest {
+  string order_id = 1;
+}
+
+message OrderReply {
+  string order_id = 1;
+  string customer_id = 2;
+  string status = 3;
+  string total_amount = 4;
+  string items_json = 5;
+  string created_at = 6;
+  string updated_at = 7;
+}

--- a/shared/Ecommerce.Shared.Protos/Protos/payment.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/payment.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.payment;
+
+service PaymentGrpc {
+  rpc GetPaymentByOrder (GetPaymentByOrderRequest) returns (PaymentReply);
+  rpc GetPaymentsByCustomer (GetPaymentsByCustomerRequest) returns (GetPaymentsByCustomerReply);
+}
+
+message GetPaymentByOrderRequest {
+  string order_id = 1;
+}
+
+message GetPaymentsByCustomerRequest {
+  string customer_id = 1;
+}
+
+message PaymentReply {
+  int64 id = 1;
+  string order_id = 2;
+  string customer_id = 3;
+  string amount = 4;
+  string currency = 5;
+  string status = 6;
+  string stripe_payment_intent_id = 7;
+  string created_at = 8;
+}
+
+message GetPaymentsByCustomerReply {
+  repeated PaymentReply payments = 1;
+}

--- a/shared/Ecommerce.Shared.Protos/Protos/product.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/product.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.product;
+
+service ProductGrpc {
+  rpc GetProduct (GetProductRequest) returns (ProductReply);
+  rpc GetProducts (GetProductsRequest) returns (GetProductsReply);
+}
+
+message GetProductRequest {
+  int64 id = 1;
+}
+
+message GetProductsRequest {
+  int32 page = 1;
+  int32 page_size = 2;
+}
+
+message ProductReply {
+  int64 id = 1;
+  string name = 2;
+  string description = 3;
+  string category = 4;
+  string price = 5;
+}
+
+message GetProductsReply {
+  repeated ProductReply products = 1;
+  int32 total_count = 2;
+  int32 page = 3;
+  int32 page_size = 4;
+}

--- a/shared/Ecommerce.Shared.Protos/Protos/stock.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/stock.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.stock;
+
+service StockGrpc {
+  rpc GetStockLevel (GetStockLevelRequest) returns (StockLevelReply);
+}
+
+message GetStockLevelRequest {
+  int64 product_id = 1;
+}
+
+message StockLevelReply {
+  int64 product_id = 1;
+  int32 available_quantity = 2;
+  int32 reserved_quantity = 3;
+}

--- a/shared/Ecommerce.Shared.Protos/Protos/user.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/user.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+option csharp_namespace = "Ecommerce.Shared.Protos";
+
+package ecommerce.user;
+
+service UserGrpc {
+  rpc GetUser (GetUserRequest) returns (UserReply);
+  rpc GetAddresses (GetAddressesRequest) returns (GetAddressesReply);
+}
+
+message GetUserRequest {
+  string user_id = 1;
+}
+
+message UserReply {
+  string id = 1;
+  string email = 2;
+  string first_name = 3;
+  string last_name = 4;
+  string phone = 5;
+  string created_at = 6;
+}
+
+message GetAddressesRequest {
+  string user_id = 1;
+}
+
+message AddressReply {
+  int64 id = 1;
+  string line1 = 2;
+  string line2 = 3;
+  string city = 4;
+  string county = 5;
+  string post_code = 6;
+  string country = 7;
+  bool is_default = 8;
+}
+
+message GetAddressesReply {
+  repeated AddressReply addresses = 1;
+}

--- a/stock-service/Dockerfile
+++ b/stock-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
 COPY stock-service/Stock.Application/Stock.Application.csproj stock-service/Stock.Application/
 COPY stock-service/Stock.Infrastructure/Stock.Infrastructure.csproj stock-service/Stock.Infrastructure/
 COPY stock-service/Stock.Service/Stock.Service.csproj stock-service/Stock.Service/

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -9,6 +9,7 @@ using Stock.Application;
 using Stock.Application.Commands;
 using Stock.Application.Consumers;
 using Stock.Infrastructure;
+using Stock.Service.Services;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}")
@@ -51,6 +52,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("StockDb")!, name: "postgresql");
 
+    builder.Services.AddGrpc();
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -79,6 +81,7 @@ try
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
     app.UseAuthorization();
+    app.MapGrpcService<StockGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/stock-service/Stock.Service/Services/StockGrpcService.cs
+++ b/stock-service/Stock.Service/Services/StockGrpcService.cs
@@ -1,0 +1,31 @@
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+using Stock.Application.Queries;
+
+namespace Stock.Service.Services;
+
+public class StockGrpcService : StockGrpc.StockGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public StockGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<StockLevelReply> GetStockLevel(GetStockLevelRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetStockQuery(request.ProductId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Stock for product {request.ProductId} not found"));
+
+        return new StockLevelReply
+        {
+            ProductId = result.ProductId,
+            AvailableQuantity = result.AvailableQuantity,
+            ReservedQuantity = result.ReservedQuantity
+        };
+    }
+}

--- a/stock-service/Stock.Service/Stock.Service.csproj
+++ b/stock-service/Stock.Service/Stock.Service.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
     <ProjectReference Include="..\Stock.Infrastructure\Stock.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
+COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
 COPY user-service/User.Application/User.Application.csproj user-service/User.Application/
 COPY user-service/User.Infrastructure/User.Infrastructure.csproj user-service/User.Infrastructure/
 COPY user-service/User.Service/User.Service.csproj user-service/User.Service/

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -9,6 +9,7 @@ using User.Application;
 using User.Application.Commands;
 using User.Application.Services;
 using User.Infrastructure;
+using User.Service.Services;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}")
@@ -49,6 +50,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("UserDb")!, name: "postgresql");
 
+    builder.Services.AddGrpc();
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>
     {
@@ -100,6 +102,7 @@ try
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
     app.UseAuthentication();
     app.UseAuthorization();
+    app.MapGrpcService<UserGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
 

--- a/user-service/User.Service/Services/UserGrpcService.cs
+++ b/user-service/User.Service/Services/UserGrpcService.cs
@@ -1,0 +1,63 @@
+using Ecommerce.Shared.Protos;
+using Grpc.Core;
+using MediatR;
+using User.Application.Queries;
+
+namespace User.Service.Services;
+
+public class UserGrpcService : UserGrpc.UserGrpcBase
+{
+    private readonly IMediator _mediator;
+
+    public UserGrpcService(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override async Task<UserReply> GetUser(GetUserRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.UserId, out var userId))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid user ID format"));
+
+        var result = await _mediator.Send(new GetProfileQuery(userId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"User {request.UserId} not found"));
+
+        return new UserReply
+        {
+            Id = result.Id.ToString(),
+            Email = result.Email ?? string.Empty,
+            FirstName = result.FirstName ?? string.Empty,
+            LastName = result.LastName ?? string.Empty,
+            Phone = result.Phone ?? string.Empty,
+            CreatedAt = result.CreatedAt.ToString("O")
+        };
+    }
+
+    public override async Task<GetAddressesReply> GetAddresses(GetAddressesRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.UserId, out var userId))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid user ID format"));
+
+        var result = await _mediator.Send(new GetAddressesQuery(userId), context.CancellationToken);
+
+        var reply = new GetAddressesReply();
+        foreach (var addr in result)
+        {
+            reply.Addresses.Add(new AddressReply
+            {
+                Id = addr.Id,
+                Line1 = addr.Line1 ?? string.Empty,
+                Line2 = addr.Line2 ?? string.Empty,
+                City = addr.City ?? string.Empty,
+                County = addr.County ?? string.Empty,
+                PostCode = addr.PostCode ?? string.Empty,
+                Country = addr.Country ?? string.Empty,
+                IsDefault = addr.IsDefault
+            });
+        }
+
+        return reply;
+    }
+}

--- a/user-service/User.Service/User.Service.csproj
+++ b/user-service/User.Service/User.Service.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
     <ProjectReference Include="..\User.Infrastructure\User.Infrastructure.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Closes #14

- Add gRPC endpoints to all 6 services (Product, Order, Stock, User, Payment, Cart) for synchronous inter-service communication
- Create shared `Ecommerce.Shared.Protos` project with `.proto` definitions for all services
- Create shared `Ecommerce.Shared.GrpcClients` project with typed client wrappers and DI extensions
- Migrate Cart Service's Product lookup from HTTP to gRPC
- Register Product gRPC client in Order Service for product validation

## Key changes

**New shared projects:**
- `shared/Ecommerce.Shared.Protos/` — 6 proto files with auto-generated server/client code
- `shared/Ecommerce.Shared.GrpcClients/` — `AddProductGrpcClient()`, `AddOrderGrpcClient()`, etc.

**gRPC services per service:**
| Service | RPCs |
|---------|------|
| Product | `GetProduct`, `GetProducts` |
| Order | `GetOrder` |
| Stock | `GetStockLevel` |
| User | `GetUser`, `GetAddresses` |
| Payment | `GetPaymentByOrder`, `GetPaymentsByCustomer` |
| Cart | `GetCart` |

**Architecture:** Same port (8080) with HTTP/1.1 + HTTP/2 content-type negotiation via Kestrel. REST endpoints remain for external access; gRPC is the primary inter-service protocol. All gRPC services delegate to existing MediatR handlers — zero business logic duplication.

**Client migration:** Cart's `ProductCatalogClient` now uses `ProductGrpc.ProductGrpcClient` instead of `HttpClient`, removing the HTTP dependency.

## Test plan

- [x] Solution builds with 0 errors
- [x] All 82 existing tests pass (7 test projects)
- [ ] Verify gRPC endpoints respond correctly with Docker Compose (`grpcurl` or similar)
- [ ] Verify Cart → Product gRPC call works end-to-end in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)