### PR TITLE
Add JWT authentication to Product, Order, Stock, and Payment APIs

### DIFF
--- a/order-service/Order.Service/Controllers/OrderController.cs
+++ b/order-service/Order.Service/Controllers/OrderController.cs
@@ -4,6 +4,7 @@ using Ecommerce.Model.Order.Request;
 using Ecommerce.Model.Order.Response;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace Order.Service.Controllers
 {
     [ApiController]
     [Route("api/orders")]
+    [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class OrderController : ControllerBase
     {

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -33,6 +33,7 @@ try
 
     builder.Services.RegisterInfrastructure(builder.Configuration);
     builder.Services.AddCorsConfiguration(builder.Configuration);
+    builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
@@ -67,6 +68,28 @@ try
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Order.Service", Version = "v1" });
+        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        {
+            Description = "JWT Authorization header using the Bearer scheme",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.ApiKey,
+            Scheme = "Bearer"
+        });
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    }
+                },
+                Array.Empty<string>()
+            }
+        });
     });
 
     var app = builder.Build();
@@ -90,6 +113,7 @@ try
 
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
+    app.UseAuthentication();
     app.UseAuthorization();
     app.MapGrpcService<OrderGrpcService>();
     app.MapControllers();

--- a/order-service/Order.Service/appsettings.json
+++ b/order-service/Order.Service/appsettings.json
@@ -15,6 +15,11 @@
   "ConnectionStrings": {
     "OrderDb": "Host=localhost;Database=order_db;Username=ecommerce;Password=ecommerce"
   },
+  "JwtSettings": {
+    "Secret": "super-secret-key-that-should-be-at-least-32-characters-long!",
+    "Issuer": "ecommerce",
+    "Audience": "ecommerce"
+  },
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }

--- a/payment-service/Payment.Service/Controllers/PaymentController.cs
+++ b/payment-service/Payment.Service/Controllers/PaymentController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Ecommerce.Model.Payment.Response;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace Payment.Service.Controllers
 {
     [ApiController]
     [Route("api/payments")]
+    [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class PaymentController : ControllerBase
     {

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -34,6 +34,7 @@ try
 
     builder.Services.RegisterInfrastructure(builder.Configuration);
     builder.Services.AddCorsConfiguration(builder.Configuration);
+    builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
@@ -62,6 +63,28 @@ try
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Payment.Service", Version = "v1" });
+        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        {
+            Description = "JWT Authorization header using the Bearer scheme",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.ApiKey,
+            Scheme = "Bearer"
+        });
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    }
+                },
+                Array.Empty<string>()
+            }
+        });
     });
 
     var app = builder.Build();
@@ -85,6 +108,7 @@ try
 
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
+    app.UseAuthentication();
     app.UseAuthorization();
     app.MapGrpcService<PaymentGrpcService>();
     app.MapControllers();

--- a/payment-service/Payment.Service/appsettings.json
+++ b/payment-service/Payment.Service/appsettings.json
@@ -18,6 +18,11 @@
   "StripeSettings": {
     "SecretKey": ""
   },
+  "JwtSettings": {
+    "Secret": "super-secret-key-that-should-be-at-least-32-characters-long!",
+    "Issuer": "ecommerce",
+    "Audience": "ecommerce"
+  },
   "RateLimiting": {
     "Read": { "PermitLimit": 60, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 10, "WindowSeconds": 60, "SegmentsPerWindow": 6 }

--- a/product-service/Product.Service/Controllers/ProductController.cs
+++ b/product-service/Product.Service/Controllers/ProductController.cs
@@ -4,6 +4,7 @@ using Ecommerce.Model.Product.Request;
 using Ecommerce.Model.Product.Response;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
@@ -88,6 +89,7 @@ namespace Product.Service.Controllers
         }
 
         [HttpPost]
+        [Authorize]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(201, Type = typeof(ProductResponse))]
         public async Task<IActionResult> Create([FromBody] CreateProductRequest req)
@@ -98,6 +100,7 @@ namespace Product.Service.Controllers
         }
 
         [HttpPut("{id}")]
+        [Authorize]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(200, Type = typeof(ProductResponse))]
         [ProducesResponseType(404)]
@@ -112,6 +115,7 @@ namespace Product.Service.Controllers
         }
 
         [HttpDelete("{id}")]
+        [Authorize]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -31,6 +31,7 @@ try
     builder.Services.RegisterInfrastructure(builder.Configuration);
     builder.Services.AddSharedInfrastructure(builder.Configuration);
     builder.Services.AddCorsConfiguration(builder.Configuration);
+    builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.Configure<CacheSettings>(
         builder.Configuration.GetSection("CacheSettings"));
@@ -56,6 +57,28 @@ try
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Product.Service", Version = "v1" });
+        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        {
+            Description = "JWT Authorization header using the Bearer scheme",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.ApiKey,
+            Scheme = "Bearer"
+        });
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    }
+                },
+                Array.Empty<string>()
+            }
+        });
     });
 
     var app = builder.Build();
@@ -79,6 +102,7 @@ try
 
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
+    app.UseAuthentication();
     app.UseAuthorization();
     app.MapGrpcService<ProductGrpcService>();
     app.MapControllers();

--- a/product-service/Product.Service/appsettings.json
+++ b/product-service/Product.Service/appsettings.json
@@ -20,6 +20,11 @@
     "ProductTtlSeconds": 300,
     "QueryTtlSeconds": 120
   },
+  "JwtSettings": {
+    "Secret": "super-secret-key-that-should-be-at-least-32-characters-long!",
+    "Issuer": "ecommerce",
+    "Audience": "ecommerce"
+  },
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }

--- a/stock-service/Stock.Service/Controllers/StockController.cs
+++ b/stock-service/Stock.Service/Controllers/StockController.cs
@@ -3,6 +3,7 @@ using Ecommerce.Model.Stock.Request;
 using Ecommerce.Model.Stock.Response;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,7 @@ namespace Stock.Service.Controllers
         }
 
         [HttpPut("{productId}")]
+        [Authorize]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(200, Type = typeof(StockResponse))]
         [ProducesResponseType(404)]

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -30,6 +30,7 @@ try
 
     builder.Services.RegisterInfrastructure(builder.Configuration);
     builder.Services.AddCorsConfiguration(builder.Configuration);
+    builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
@@ -57,6 +58,28 @@ try
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Stock.Service", Version = "v1" });
+        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        {
+            Description = "JWT Authorization header using the Bearer scheme",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.ApiKey,
+            Scheme = "Bearer"
+        });
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    }
+                },
+                Array.Empty<string>()
+            }
+        });
     });
 
     var app = builder.Build();
@@ -80,6 +103,7 @@ try
 
     app.UseHttpsRedirection();
     app.UseCors(Ecommerce.Shared.Infrastructure.DependencyInjection.CorsPolicyName);
+    app.UseAuthentication();
     app.UseAuthorization();
     app.MapGrpcService<StockGrpcService>();
     app.MapControllers();

--- a/stock-service/Stock.Service/appsettings.json
+++ b/stock-service/Stock.Service/appsettings.json
@@ -18,6 +18,11 @@
   "StockSettings": {
     "LowStockThreshold": 10
   },
+  "JwtSettings": {
+    "Secret": "super-secret-key-that-should-be-at-least-32-characters-long!",
+    "Issuer": "ecommerce",
+    "Audience": "ecommerce"
+  },
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }


### PR DESCRIPTION
## Summary

Closes #42

- Wires up `AddJwtAuthentication()` (shared infrastructure) and `app.UseAuthentication()` middleware in Product, Order, Stock, and Payment services
- Adds Swagger Bearer token security definition to all 4 services for easy testing
- Adds `JwtSettings` configuration section to all 4 appsettings.json (matching User Service's issuer/audience/secret)
- Applies `[Authorize]` attributes per endpoint:
  - **Product**: GET endpoints remain public (browsing); POST/PUT/DELETE require auth
  - **Order**: All endpoints require auth (`[Authorize]` on controller class)
  - **Stock**: GET remains public (stock checks); PUT requires auth
  - **Payment**: All endpoints require auth (`[Authorize]` on controller class)

## Test plan

- [ ] Unauthenticated POST/PUT/DELETE to Product API returns 401
- [ ] Unauthenticated GET to Product API still returns 200
- [ ] Unauthenticated requests to Order/Payment APIs return 401
- [ ] Valid JWT from User Service `/api/auth/login` grants access to protected endpoints
- [ ] Health check `/health` and Swagger remain accessible without auth
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)