### PR TITLE
Add idempotency keys to API write endpoints (#50)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__OrderDb=Host=pgbouncer;Port=6432;Database=order_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__Redis=redis:6379
       - GrpcClients__ProductService=http://product:8080
     healthcheck: *app-healthcheck
     networks:
@@ -126,6 +127,8 @@ services:
       pgbouncer:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       product:
         condition: service_healthy
@@ -142,6 +145,7 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__StockDb=Host=pgbouncer;Port=6432;Database=stock_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__Redis=redis:6379
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -149,6 +153,8 @@ services:
       pgbouncer:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   user:
@@ -180,12 +186,15 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__PaymentDb=Host=pgbouncer;Port=6432;Database=payment_db;Username=ecommerce;Password=ecommerce
+      - ConnectionStrings__Redis=redis:6379
       - StripeSettings__SecretKey=${STRIPE_SECRET_KEY:-}
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
     depends_on:
       pgbouncer:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy

--- a/order-service/Order.Service/Controllers/OrderController.cs
+++ b/order-service/Order.Service/Controllers/OrderController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Ecommerce.Model.Order.Request;
 using Ecommerce.Model.Order.Response;
+using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -29,6 +30,7 @@ namespace Order.Service.Controllers
         }
 
         [HttpPost]
+        [IdempotentEndpoint]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(202, Type = typeof(OrderResponse))]
         public async Task<IActionResult> PlaceOrder([FromBody] PlaceOrderRequest request)

--- a/order-service/Order.Service/Order.Service.csproj
+++ b/order-service/Order.Service/Order.Service.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -35,6 +35,15 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddIdempotency(builder.Configuration);
+
+    var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
+    builder.Services.AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = redisConnection;
+        options.InstanceName = "order:";
+    });
+
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
         bus.AddSagaStateMachine<OrderStateMachine, OrderSagaState>()
@@ -64,7 +73,10 @@ try
 
     builder.Services.AddGrpc();
     builder.Services.AddProductGrpcClient(builder.Configuration);
-    builder.Services.AddControllers();
+    builder.Services.AddControllers(options =>
+    {
+        options.Filters.AddService<Ecommerce.Shared.Infrastructure.Idempotency.IdempotencyFilter>();
+    });
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Order.Service", Version = "v1" });

--- a/order-service/Order.Service/appsettings.json
+++ b/order-service/Order.Service/appsettings.json
@@ -13,7 +13,8 @@
     "AllowedHeaders": ["Content-Type", "Authorization", "X-Correlation-Id"]
   },
   "ConnectionStrings": {
-    "OrderDb": "Host=localhost;Database=order_db;Username=ecommerce;Password=ecommerce"
+    "OrderDb": "Host=localhost;Database=order_db;Username=ecommerce;Password=ecommerce",
+    "Redis": "localhost:6379"
   },
   "JwtSettings": {
     "Secret": "super-secret-key-that-should-be-at-least-32-characters-long!",

--- a/payment-service/Payment.Service/Controllers/PaymentController.cs
+++ b/payment-service/Payment.Service/Controllers/PaymentController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ecommerce.Model.Payment.Response;
+using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -50,6 +51,7 @@ namespace Payment.Service.Controllers
         }
 
         [HttpPost("{paymentId:long}/refund")]
+        [IdempotentEndpoint]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(200, Type = typeof(PaymentResponse))]
         [ProducesResponseType(404)]

--- a/payment-service/Payment.Service/Payment.Service.csproj
+++ b/payment-service/Payment.Service/Payment.Service.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -36,6 +36,15 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddIdempotency(builder.Configuration);
+
+    var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
+    builder.Services.AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = redisConnection;
+        options.InstanceName = "payment:";
+    });
+
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
         bus.AddConsumer<ProcessPaymentConsumer>();
@@ -59,7 +68,10 @@ try
         .AddNpgSql(builder.Configuration.GetConnectionString("PaymentDb")!, name: "postgresql");
 
     builder.Services.AddGrpc();
-    builder.Services.AddControllers();
+    builder.Services.AddControllers(options =>
+    {
+        options.Filters.AddService<Ecommerce.Shared.Infrastructure.Idempotency.IdempotencyFilter>();
+    });
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Payment.Service", Version = "v1" });

--- a/payment-service/Payment.Service/appsettings.json
+++ b/payment-service/Payment.Service/appsettings.json
@@ -13,7 +13,8 @@
     "AllowedHeaders": ["Content-Type", "Authorization", "X-Correlation-Id"]
   },
   "ConnectionStrings": {
-    "PaymentDb": "Host=localhost;Database=payment_db;Username=ecommerce;Password=ecommerce"
+    "PaymentDb": "Host=localhost;Database=payment_db;Username=ecommerce;Password=ecommerce",
+    "Redis": "localhost:6379"
   },
   "StripeSettings": {
     "SecretKey": ""

--- a/product-service/Product.Service/Controllers/ProductController.cs
+++ b/product-service/Product.Service/Controllers/ProductController.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Ecommerce.Model;
 using Ecommerce.Model.Product.Request;
 using Ecommerce.Model.Product.Response;
+using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -90,6 +91,7 @@ namespace Product.Service.Controllers
 
         [HttpPost]
         [Authorize]
+        [IdempotentEndpoint]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(201, Type = typeof(ProductResponse))]
         public async Task<IActionResult> Create([FromBody] CreateProductRequest req)
@@ -101,6 +103,7 @@ namespace Product.Service.Controllers
 
         [HttpPut("{id}")]
         [Authorize]
+        [IdempotentEndpoint]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(200, Type = typeof(ProductResponse))]
         [ProducesResponseType(404)]

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -33,6 +33,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddIdempotency(builder.Configuration);
     builder.Services.Configure<CacheSettings>(
         builder.Configuration.GetSection("CacheSettings"));
 
@@ -53,7 +54,10 @@ try
         .AddRedis(builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379", name: "redis");
 
     builder.Services.AddGrpc();
-    builder.Services.AddControllers();
+    builder.Services.AddControllers(options =>
+    {
+        options.Filters.AddService<Ecommerce.Shared.Infrastructure.Idempotency.IdempotencyFilter>();
+    });
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Product.Service", Version = "v1" });

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Ecommerce.Shared.Infrastructure.Authentication;
 using Ecommerce.Shared.Infrastructure.Cors;
+using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -130,6 +131,17 @@ public static class DependencyInjection
                         QueueLimit = 0
                     }));
         });
+
+        return services;
+    }
+
+    public static IServiceCollection AddIdempotency(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<IdempotencySettings>(
+            configuration.GetSection("IdempotencySettings"));
+        services.AddScoped<IdempotencyFilter>();
 
         return services;
     }

--- a/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
+++ b/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotencyFilter.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotencyFilter.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ecommerce.Shared.Infrastructure.Idempotency;
+
+public class IdempotencyFilter : IAsyncActionFilter
+{
+    private const string IdempotencyKeyHeader = "Idempotency-Key";
+    private const string CachePrefix = "idempotency:";
+
+    private readonly IDistributedCache _cache;
+    private readonly IdempotencySettings _settings;
+    private readonly ILogger<IdempotencyFilter> _logger;
+
+    public IdempotencyFilter(
+        IDistributedCache cache,
+        IOptions<IdempotencySettings> settings,
+        ILogger<IdempotencyFilter> logger)
+    {
+        _cache = cache;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var endpoint = context.ActionDescriptor.EndpointMetadata;
+        var hasAttribute = false;
+        foreach (var metadata in endpoint)
+        {
+            if (metadata is IdempotentEndpointAttribute)
+            {
+                hasAttribute = true;
+                break;
+            }
+        }
+
+        if (!hasAttribute)
+        {
+            await next();
+            return;
+        }
+
+        if (!context.HttpContext.Request.Headers.TryGetValue(IdempotencyKeyHeader, out var idempotencyKey)
+            || string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            await next();
+            return;
+        }
+
+        var routePath = context.HttpContext.Request.Path.Value ?? "";
+        var cacheKey = $"{CachePrefix}{routePath}:{idempotencyKey}";
+
+        var cached = await _cache.GetAsync(cacheKey);
+        if (cached != null)
+        {
+            _logger.LogInformation("Idempotent replay for key {IdempotencyKey} on {Path}", idempotencyKey.ToString(), routePath);
+            var entry = IdempotencyCacheEntry.Deserialize(cached);
+            context.HttpContext.Response.StatusCode = entry.StatusCode;
+            context.HttpContext.Response.ContentType = entry.ContentType;
+            context.Result = new IdempotentContentResult(entry);
+            return;
+        }
+
+        var executedContext = await next();
+
+        if (executedContext.Exception == null && executedContext.Result is ObjectResult objectResult)
+        {
+            var statusCode = objectResult.StatusCode ?? 200;
+            var body = System.Text.Json.JsonSerializer.Serialize(objectResult.Value);
+            var entry = new IdempotencyCacheEntry
+            {
+                StatusCode = statusCode,
+                ContentType = "application/json",
+                Body = body
+            };
+
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_settings.TtlHours)
+            };
+
+            await _cache.SetAsync(cacheKey, entry.Serialize(), options);
+            _logger.LogDebug("Cached idempotent response for key {IdempotencyKey} on {Path}", idempotencyKey.ToString(), routePath);
+        }
+    }
+}
+
+internal class IdempotencyCacheEntry
+{
+    public int StatusCode { get; set; }
+    public string ContentType { get; set; }
+    public string Body { get; set; }
+
+    public byte[] Serialize()
+    {
+        return System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(this);
+    }
+
+    public static IdempotencyCacheEntry Deserialize(byte[] data)
+    {
+        return System.Text.Json.JsonSerializer.Deserialize<IdempotencyCacheEntry>(data);
+    }
+}
+
+internal class IdempotentContentResult : IActionResult
+{
+    private readonly IdempotencyCacheEntry _entry;
+
+    public IdempotentContentResult(IdempotencyCacheEntry entry)
+    {
+        _entry = entry;
+    }
+
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        context.HttpContext.Response.StatusCode = _entry.StatusCode;
+        context.HttpContext.Response.ContentType = _entry.ContentType;
+        await context.HttpContext.Response.WriteAsync(_entry.Body);
+    }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotencySettings.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotencySettings.cs
@@ -1,0 +1,6 @@
+namespace Ecommerce.Shared.Infrastructure.Idempotency;
+
+public class IdempotencySettings
+{
+    public int TtlHours { get; set; } = 24;
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotentEndpointAttribute.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Idempotency/IdempotentEndpointAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Ecommerce.Shared.Infrastructure.Idempotency;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class IdempotentEndpointAttribute : Attribute, IFilterMetadata
+{
+}

--- a/stock-service/Stock.Service/Controllers/StockController.cs
+++ b/stock-service/Stock.Service/Controllers/StockController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Ecommerce.Model.Stock.Request;
 using Ecommerce.Model.Stock.Response;
+using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -41,6 +42,7 @@ namespace Stock.Service.Controllers
 
         [HttpPut("{productId}")]
         [Authorize]
+        [IdempotentEndpoint]
         [EnableRateLimiting(RateLimitPolicies.Write)]
         [ProducesResponseType(200, Type = typeof(StockResponse))]
         [ProducesResponseType(404)]

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -32,6 +32,15 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddIdempotency(builder.Configuration);
+
+    var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
+    builder.Services.AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = redisConnection;
+        options.InstanceName = "stock:";
+    });
+
     builder.Services.AddSharedInfrastructure(builder.Configuration, bus =>
     {
         bus.AddConsumer<ReserveStockConsumer>();
@@ -54,7 +63,10 @@ try
         .AddNpgSql(builder.Configuration.GetConnectionString("StockDb")!, name: "postgresql");
 
     builder.Services.AddGrpc();
-    builder.Services.AddControllers();
+    builder.Services.AddControllers(options =>
+    {
+        options.Filters.AddService<Ecommerce.Shared.Infrastructure.Idempotency.IdempotencyFilter>();
+    });
     builder.Services.AddSwaggerGen(c =>
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Stock.Service", Version = "v1" });

--- a/stock-service/Stock.Service/Stock.Service.csproj
+++ b/stock-service/Stock.Service/Stock.Service.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/stock-service/Stock.Service/appsettings.json
+++ b/stock-service/Stock.Service/appsettings.json
@@ -13,7 +13,8 @@
     "AllowedHeaders": ["Content-Type", "Authorization", "X-Correlation-Id"]
   },
   "ConnectionStrings": {
-    "StockDb": "Host=localhost;Database=stock_db;Username=ecommerce;Password=ecommerce"
+    "StockDb": "Host=localhost;Database=stock_db;Username=ecommerce;Password=ecommerce",
+    "Redis": "localhost:6379"
   },
   "StockSettings": {
     "LowStockThreshold": 10


### PR DESCRIPTION
## Summary

Closes #50

- Adds `IdempotencyFilter` action filter in shared infrastructure that intercepts requests with an `Idempotency-Key` header, caches the response in Redis, and replays cached responses for duplicate requests within a configurable TTL (default 24h)
- `[IdempotentEndpoint]` attribute opts specific endpoints into idempotency protection
- Header is optional — requests without `Idempotency-Key` execute normally
- Key is scoped per route path to avoid cross-endpoint collisions

### Endpoints protected:
- **Product**: `POST /product` (Create), `PUT /product/{id}` (Update)
- **Order**: `POST /api/orders` (PlaceOrder)
- **Stock**: `PUT /api/stock/{productId}` (UpdateStock)
- **Payment**: `POST /api/payments/{id}/refund` (RefundPayment)

### Infrastructure changes:
- Added `Microsoft.Extensions.Caching.StackExchangeRedis` to Order, Stock, and Payment services
- Added Redis connection strings to appsettings and docker-compose for all services
- Order, Stock, and Payment now depend on Redis in docker-compose

## Test plan

- [ ] POST with `Idempotency-Key: abc123` returns original response
- [ ] Same POST with `Idempotency-Key: abc123` returns cached response (no duplicate created)
- [ ] POST without `Idempotency-Key` header works normally
- [ ] Different `Idempotency-Key` values create separate resources
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)