### PR TITLE
Add API versioning across all services (#47)

### DIFF
--- a/cart-service/Cart.Service/Controllers/CartController.cs
+++ b/cart-service/Cart.Service/Controllers/CartController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Cart.Application.Commands;
 using Cart.Application.DTOs;
 using Cart.Application.Queries;
@@ -9,7 +10,8 @@ using Microsoft.AspNetCore.RateLimiting;
 namespace Cart.Service.Controllers;
 
 [ApiController]
-[Route("[controller]")]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/cart")]
 [EnableRateLimiting(RateLimitPolicies.Read)]
 public class CartController : ControllerBase
 {

--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -44,6 +44,7 @@ try
     builder.Services.AddHealthChecks()
         .AddRedis(builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379", name: "redis");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddProductGrpcClient(builder.Configuration);
     builder.Services.AddControllers();

--- a/order-service/Order.Service/Controllers/OrderController.cs
+++ b/order-service/Order.Service/Controllers/OrderController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Ecommerce.Model.Order.Request;
 using Ecommerce.Model.Order.Response;
 using Ecommerce.Shared.Infrastructure.Idempotency;
@@ -15,7 +16,8 @@ using Order.Application.Queries;
 namespace Order.Service.Controllers
 {
     [ApiController]
-    [Route("api/orders")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/orders")]
     [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class OrderController : ControllerBase

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -77,6 +77,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("OrderDb")!, name: "postgresql");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddProductGrpcClient(builder.Configuration);
     builder.Services.AddControllers(options =>

--- a/payment-service/Payment.Service/Controllers/PaymentController.cs
+++ b/payment-service/Payment.Service/Controllers/PaymentController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Ecommerce.Model.Payment.Response;
 using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
@@ -15,7 +16,8 @@ using Payment.Application.Queries;
 namespace Payment.Service.Controllers
 {
     [ApiController]
-    [Route("api/payments")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/payments")]
     [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class PaymentController : ControllerBase

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -74,6 +74,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("PaymentDb")!, name: "postgresql");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddControllers(options =>
     {

--- a/product-service/Product.Service/Controllers/ProductController.cs
+++ b/product-service/Product.Service/Controllers/ProductController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Ecommerce.Model;
 using Ecommerce.Model.Product.Request;
 using Ecommerce.Model.Product.Response;
@@ -15,7 +16,8 @@ using Product.Application.Queries;
 namespace Product.Service.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/products")]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class ProductController : ControllerBase
     {

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -61,6 +61,7 @@ try
         .AddNpgSql(builder.Configuration.GetConnectionString("ProductDb")!, name: "postgresql")
         .AddRedis(builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379", name: "redis");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddControllers(options =>
     {

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Ecommerce.Shared.Infrastructure.Authentication;
 using Ecommerce.Shared.Infrastructure.Cors;
 using Ecommerce.Shared.Infrastructure.Idempotency;
@@ -142,6 +143,27 @@ public static class DependencyInjection
         services.Configure<IdempotencySettings>(
             configuration.GetSection("IdempotencySettings"));
         services.AddScoped<IdempotencyFilter>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddApiVersioningConfiguration(
+        this IServiceCollection services)
+    {
+        services.AddApiVersioning(options =>
+        {
+            options.DefaultApiVersion = new ApiVersion(1, 0);
+            options.AssumeDefaultVersionWhenUnspecified = true;
+            options.ReportApiVersions = true;
+            options.ApiVersionReader = ApiVersionReader.Combine(
+                new UrlSegmentApiVersionReader(),
+                new HeaderApiVersionReader("X-Api-Version"));
+        })
+        .AddApiExplorer(options =>
+        {
+            options.GroupNameFormat = "'v'VVV";
+            options.SubstituteApiVersionInUrl = true;
+        });
 
         return services;
     }

--- a/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
+++ b/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
   </ItemGroup>
 

--- a/stock-service/Stock.Service/Controllers/StockController.cs
+++ b/stock-service/Stock.Service/Controllers/StockController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Ecommerce.Model.Stock.Request;
 using Ecommerce.Model.Stock.Response;
 using Ecommerce.Shared.Infrastructure.Idempotency;
@@ -14,7 +15,8 @@ using Stock.Application.Queries;
 namespace Stock.Service.Controllers
 {
     [ApiController]
-    [Route("api/stock")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/stock")]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class StockController : ControllerBase
     {

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -69,6 +69,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("StockDb")!, name: "postgresql");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddControllers(options =>
     {

--- a/user-service/User.Service/Controllers/AddressController.cs
+++ b/user-service/User.Service/Controllers/AddressController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Asp.Versioning;
 using Ecommerce.Model.User.Request;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
@@ -11,7 +12,8 @@ using User.Application.Queries;
 namespace User.Service.Controllers
 {
     [ApiController]
-    [Route("api/users/me/addresses")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/users/me/addresses")]
     [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class AddressController : ControllerBase

--- a/user-service/User.Service/Controllers/AuthController.cs
+++ b/user-service/User.Service/Controllers/AuthController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Ecommerce.Model.User.Request;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
@@ -8,7 +9,8 @@ using User.Application.Commands;
 namespace User.Service.Controllers
 {
     [ApiController]
-    [Route("api/auth")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/auth")]
     [EnableRateLimiting(RateLimitPolicies.Write)]
     public class AuthController : ControllerBase
     {

--- a/user-service/User.Service/Controllers/UserController.cs
+++ b/user-service/User.Service/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Asp.Versioning;
 using Ecommerce.Model.User.Request;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MediatR;
@@ -11,7 +12,8 @@ using User.Application.Queries;
 namespace User.Service.Controllers
 {
     [ApiController]
-    [Route("api/users")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/users")]
     [Authorize]
     [EnableRateLimiting(RateLimitPolicies.Read)]
     public class UserController : ControllerBase

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -58,6 +58,7 @@ try
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("UserDb")!, name: "postgresql");
 
+    builder.Services.AddApiVersioningConfiguration();
     builder.Services.AddGrpc();
     builder.Services.AddControllers();
     builder.Services.AddSwaggerGen(c =>


### PR DESCRIPTION
Closes #47

## Summary
- Added `Asp.Versioning.Mvc` and `Asp.Versioning.Mvc.ApiExplorer` packages to shared infrastructure
- Created `AddApiVersioningConfiguration()` extension method supporting URL path segment (`/api/v1/...`) and header (`X-Api-Version`) versioning
- All 8 controllers across 6 services versioned at v1 with route template `api/v{version:apiVersion}/...`
- Default version is 1.0 when unspecified, with `api-supported-versions` response header

## Changes
- **Shared Infrastructure**: New `AddApiVersioningConfiguration()` in `DependencyInjection.cs`
- **All controllers**: Added `[ApiVersion("1.0")]` attribute and updated routes from `api/...` or `[controller]` to `api/v{version:apiVersion}/...`
- **All Program.cs**: Added `builder.Services.AddApiVersioningConfiguration()` call

## Test plan
- [ ] Verify all endpoints accessible at `/api/v1/...` paths
- [ ] Verify `api-supported-versions` header present in responses
- [ ] Verify `X-Api-Version: 1.0` header also works for version selection
- [ ] Swagger UI shows versioned endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)