### PR TITLE
Add request/response logging with sensitive data masking (#56)

### DIFF
--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -4,6 +4,7 @@ using Cart.Infrastructure;
 using Cart.Service.Services;
 using Ecommerce.Shared.GrpcClients;
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -30,6 +31,7 @@ try
     builder.Services.RegisterInfrastructure(builder.Configuration);
     builder.Services.AddSharedInfrastructure(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(AddToCartCommand).Assembly);
@@ -56,6 +58,7 @@ try
     var app = builder.Build();
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/cart-service/Cart.Service/appsettings.json
+++ b/cart-service/Cart.Service/appsettings.json
@@ -19,5 +19,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 30, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -1,5 +1,6 @@
 using Ecommerce.Shared.GrpcClients;
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -35,6 +36,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
@@ -120,6 +122,7 @@ try
     }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/order-service/Order.Service/appsettings.json
+++ b/order-service/Order.Service/appsettings.json
@@ -24,5 +24,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -1,4 +1,5 @@
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -37,6 +38,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
@@ -116,6 +118,7 @@ try
     }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/payment-service/Payment.Service/appsettings.json
+++ b/payment-service/Payment.Service/appsettings.json
@@ -27,5 +27,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 60, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 10, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -1,4 +1,5 @@
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -41,6 +42,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddIdempotency(builder.Configuration);
     builder.Services.Configure<CacheSettings>(
         builder.Configuration.GetSection("CacheSettings"));
@@ -103,6 +105,7 @@ try
     }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/product-service/Product.Service/appsettings.json
+++ b/product-service/Product.Service/appsettings.json
@@ -28,5 +28,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,7 @@ using Asp.Versioning;
 using Ecommerce.Shared.Infrastructure.Authentication;
 using Ecommerce.Shared.Infrastructure.Cors;
 using Ecommerce.Shared.Infrastructure.Idempotency;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -164,6 +165,16 @@ public static class DependencyInjection
             options.GroupNameFormat = "'v'VVV";
             options.SubstituteApiVersionInUrl = true;
         });
+
+        return services;
+    }
+
+    public static IServiceCollection AddRequestResponseLogging(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<RequestResponseLoggingSettings>(
+            configuration.GetSection("RequestResponseLogging"));
 
         return services;
     }

--- a/shared/Ecommerce.Shared.Infrastructure/Logging/RequestResponseLoggingMiddleware.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Logging/RequestResponseLoggingMiddleware.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ecommerce.Shared.Infrastructure.Logging;
+
+public class RequestResponseLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly RequestResponseLoggingSettings _settings;
+    private readonly ILogger<RequestResponseLoggingMiddleware> _logger;
+
+    public RequestResponseLoggingMiddleware(
+        RequestDelegate next,
+        IOptions<RequestResponseLoggingSettings> settings,
+        ILogger<RequestResponseLoggingMiddleware> logger)
+    {
+        _next = next;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!_settings.Enabled)
+        {
+            await _next(context);
+            return;
+        }
+
+        await LogRequest(context);
+
+        var originalBodyStream = context.Response.Body;
+        using var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
+
+        await _next(context);
+
+        await LogResponse(context, responseBody, originalBodyStream);
+    }
+
+    private async Task LogRequest(HttpContext context)
+    {
+        context.Request.EnableBuffering();
+
+        var body = string.Empty;
+        if (context.Request.ContentLength > 0)
+        {
+            using var reader = new StreamReader(
+                context.Request.Body,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                leaveOpen: true);
+            body = await reader.ReadToEndAsync();
+            context.Request.Body.Position = 0;
+        }
+
+        var maskedBody = MaskSensitiveData(Truncate(body));
+
+        _logger.LogDebug(
+            "HTTP {Method} {Path}{QueryString} - Body: {RequestBody}",
+            context.Request.Method,
+            context.Request.Path,
+            context.Request.QueryString,
+            maskedBody);
+    }
+
+    private async Task LogResponse(HttpContext context, MemoryStream responseBody, Stream originalBodyStream)
+    {
+        responseBody.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(responseBody, Encoding.UTF8).ReadToEndAsync();
+        responseBody.Seek(0, SeekOrigin.Begin);
+
+        await responseBody.CopyToAsync(originalBodyStream);
+        context.Response.Body = originalBodyStream;
+
+        var maskedBody = MaskSensitiveData(Truncate(body));
+
+        _logger.LogDebug(
+            "HTTP {StatusCode} {Method} {Path} - Body: {ResponseBody}",
+            context.Response.StatusCode,
+            context.Request.Method,
+            context.Request.Path,
+            maskedBody);
+    }
+
+    private string Truncate(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= _settings.MaxBodyLength)
+            return value;
+
+        return value[.._settings.MaxBodyLength] + "...[truncated]";
+    }
+
+    private string MaskSensitiveData(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return body;
+
+        try
+        {
+            var node = JsonNode.Parse(body);
+            if (node != null)
+            {
+                MaskNode(node);
+                return node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON — return as-is
+        }
+
+        return body;
+    }
+
+    private void MaskNode(JsonNode node)
+    {
+        if (node is JsonObject obj)
+        {
+            foreach (var property in obj.ToArray())
+            {
+                if (_settings.SensitiveFields.Contains(property.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    obj[property.Key] = "***MASKED***";
+                }
+                else if (property.Value != null)
+                {
+                    MaskNode(property.Value);
+                }
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var item in array)
+            {
+                if (item != null)
+                    MaskNode(item);
+            }
+        }
+    }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Logging/RequestResponseLoggingSettings.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Logging/RequestResponseLoggingSettings.cs
@@ -1,0 +1,23 @@
+namespace Ecommerce.Shared.Infrastructure.Logging;
+
+public class RequestResponseLoggingSettings
+{
+    public bool Enabled { get; set; }
+    public int MaxBodyLength { get; set; } = 4096;
+    public string[] SensitiveFields { get; set; } =
+    {
+        "password",
+        "currentPassword",
+        "newPassword",
+        "token",
+        "refreshToken",
+        "accessToken",
+        "secret",
+        "secretKey",
+        "cardNumber",
+        "cvv",
+        "cvc",
+        "apiKey",
+        "authorization"
+    };
+}

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -1,4 +1,5 @@
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -33,6 +34,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
@@ -111,6 +113,7 @@ try
     }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/stock-service/Stock.Service/appsettings.json
+++ b/stock-service/Stock.Service/appsettings.json
@@ -27,5 +27,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 100, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 20, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -1,4 +1,5 @@
 using Ecommerce.Shared.Infrastructure;
+using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Middleware;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -40,6 +41,7 @@ try
     });
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
+    builder.Services.AddRequestResponseLogging(builder.Configuration);
     builder.Services.AddJwtAuthentication(builder.Configuration);
 
     builder.Services.AddScoped<ITokenService, TokenService>();
@@ -97,6 +99,7 @@ try
     }
 
     app.UseMiddleware<CorrelationIdMiddleware>();
+    app.UseMiddleware<RequestResponseLoggingMiddleware>();
     app.UseRateLimiter();
     app.UseSerilogRequestLogging();
     app.UseExceptionHandler();

--- a/user-service/User.Service/appsettings.json
+++ b/user-service/User.Service/appsettings.json
@@ -33,5 +33,9 @@
   "RateLimiting": {
     "Read": { "PermitLimit": 60, "WindowSeconds": 60, "SegmentsPerWindow": 6 },
     "Write": { "PermitLimit": 10, "WindowSeconds": 60, "SegmentsPerWindow": 6 }
+  },
+  "RequestResponseLogging": {
+    "Enabled": false,
+    "MaxBodyLength": 4096
   }
 }


### PR DESCRIPTION
Closes #56

## Summary
- Added `RequestResponseLoggingMiddleware` in shared infrastructure that logs request/response bodies at Debug level
- Sensitive fields (passwords, tokens, card numbers, API keys) are automatically masked using recursive JSON traversal
- Logging is opt-in via `RequestResponseLogging:Enabled` configuration setting
- Large bodies are truncated to configurable `MaxBodyLength` (default 4096 chars) to prevent log bloat

## Changes
- **New**: `Logging/RequestResponseLoggingSettings.cs` — configuration model with default sensitive field list
- **New**: `Logging/RequestResponseLoggingMiddleware.cs` — middleware that buffers request/response bodies, masks sensitive JSON fields, and logs at Debug level
- **DependencyInjection.cs**: Added `AddRequestResponseLogging()` extension method
- **All 6 Program.cs**: Registered middleware after `CorrelationIdMiddleware` and before `UseSerilogRequestLogging`
- **All 6 appsettings.json**: Added `RequestResponseLogging` section (disabled by default)

## Test plan
- [ ] Enable logging in Development and verify request/response bodies appear at Debug level
- [ ] Verify password, token, and card fields are masked as `***MASKED***`
- [ ] Verify bodies exceeding MaxBodyLength are truncated with `...[truncated]`
- [ ] Verify non-JSON bodies are logged as-is without errors
- [ ] Verify logging can be toggled off via configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)