### PR TITLE
Add distributed tracing with OpenTelemetry and Jaeger (#40)

### DIFF
--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -32,6 +32,7 @@ try
     builder.Services.AddSharedInfrastructure(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Cart.Service");
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(AddToCartCommand).Assembly);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,17 @@ services:
     networks:
       - ecommerce-network
 
+  jaeger:
+    image: jaegertracing/all-in-one:1.62
+    profiles: ["tools"]
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    networks:
+      - ecommerce-network
+
   # ── Application services (profile: app) ──────────
   product:
     build:
@@ -97,6 +108,7 @@ services:
     environment:
       - ConnectionStrings__ProductDb=Host=pgbouncer;Port=6432;Database=product_db;Username=ecommerce;Password=ecommerce
       - ConnectionStrings__Redis=redis:6379
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -120,6 +132,7 @@ services:
       - ConnectionStrings__OrderDb=Host=pgbouncer;Port=6432;Database=order_db;Username=ecommerce;Password=ecommerce
       - ConnectionStrings__Redis=redis:6379
       - GrpcClients__ProductService=http://product:8080
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -146,6 +159,7 @@ services:
     environment:
       - ConnectionStrings__StockDb=Host=pgbouncer;Port=6432;Database=stock_db;Username=ecommerce;Password=ecommerce
       - ConnectionStrings__Redis=redis:6379
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -167,6 +181,7 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__UserDb=Host=pgbouncer;Port=6432;Database=user_db;Username=ecommerce;Password=ecommerce
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -188,6 +203,7 @@ services:
       - ConnectionStrings__PaymentDb=Host=pgbouncer;Port=6432;Database=payment_db;Username=ecommerce;Password=ecommerce
       - ConnectionStrings__Redis=redis:6379
       - StripeSettings__SecretKey=${STRIPE_SECRET_KEY:-}
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network
@@ -210,6 +226,7 @@ services:
     environment:
       - ConnectionStrings__Redis=redis:6379
       - GrpcClients__ProductService=http://product:8080
+      - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
       - ecommerce-network

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -37,6 +37,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Order.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -39,6 +39,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Payment.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -43,6 +43,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Product.Service");
     builder.Services.AddIdempotency(builder.Configuration);
     builder.Services.Configure<CacheSettings>(
         builder.Configuration.GetSection("CacheSettings"));

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -16,6 +16,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 namespace Ecommerce.Shared.Infrastructure;
 
@@ -165,6 +167,31 @@ public static class DependencyInjection
             options.GroupNameFormat = "'v'VVV";
             options.SubstituteApiVersionInUrl = true;
         });
+
+        return services;
+    }
+
+    public static IServiceCollection AddOpenTelemetryTracing(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string serviceName)
+    {
+        var otlpEndpoint = configuration["OpenTelemetry:OtlpEndpoint"] ?? "http://localhost:4317";
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(serviceName))
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddEntityFrameworkCoreInstrumentation()
+                    .AddSource("MassTransit")
+                    .AddOtlpExporter(options =>
+                    {
+                        options.Endpoint = new Uri(otlpEndpoint);
+                    });
+            });
 
         return services;
     }

--- a/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
+++ b/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
@@ -17,6 +17,11 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -35,6 +35,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Stock.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
     var redisConnection = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -42,6 +42,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddOpenTelemetryTracing(builder.Configuration, "User.Service");
     builder.Services.AddJwtAuthentication(builder.Configuration);
 
     builder.Services.AddScoped<ITokenService, TokenService>();


### PR DESCRIPTION
Closes #40

## Summary
- Added OpenTelemetry distributed tracing to all 6 services with ASP.NET Core, HTTP client, Entity Framework Core, and MassTransit instrumentation
- Traces are exported via OTLP to Jaeger for visualization of cross-service request flows
- Jaeger UI available at `localhost:16686` when running with the `tools` docker-compose profile

## Changes
- **Shared Infrastructure csproj**: Added OpenTelemetry packages (`Extensions.Hosting`, `Instrumentation.AspNetCore`, `Instrumentation.Http`, `Instrumentation.EntityFrameworkCore`, `Exporter.OpenTelemetryProtocol`)
- **DependencyInjection.cs**: New `AddOpenTelemetryTracing()` extension method configuring trace sources and OTLP exporter
- **All 6 Program.cs**: Added `AddOpenTelemetryTracing(configuration, "ServiceName")` call
- **docker-compose.yml**: Added Jaeger all-in-one container (tools profile), OTLP endpoint env var for all app services

## Test plan
- [ ] Run `docker compose --profile tools up` and verify Jaeger UI at `localhost:16686`
- [ ] With app profile, place an order and verify full trace in Jaeger: PlaceOrder → ReserveStock → ProcessPayment → Confirmed
- [ ] Verify each service reports spans with correct service name
- [ ] Verify EF Core and HTTP client spans appear in traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)