### PR TITLE
Add resilience policies with Polly for payment gateway

### DIFF
--- a/payment-service/Payment.Application.Tests/Services/ResilientPaymentGatewayTests.cs
+++ b/payment-service/Payment.Application.Tests/Services/ResilientPaymentGatewayTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Payment.Application.Services;
+using Stripe;
+
+namespace Payment.Application.Tests.Services;
+
+public class ResilientPaymentGatewayTests
+{
+    private readonly IPaymentGateway _innerGateway;
+    private readonly ILogger<ResilientPaymentGateway> _logger;
+
+    public ResilientPaymentGatewayTests()
+    {
+        _innerGateway = Substitute.For<IPaymentGateway>();
+        _logger = Substitute.For<ILogger<ResilientPaymentGateway>>();
+    }
+
+    [Fact]
+    public async Task CreatePaymentIntent_RetriesOnTransientStripeError()
+    {
+        var callCount = 0;
+        _innerGateway.CreatePaymentIntentAsync(
+            Arg.Any<decimal>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>())
+            .ReturnsForAnyArgs(callInfo =>
+            {
+                callCount++;
+                if (callCount <= 2)
+                    throw new StripeException(HttpStatusCode.ServiceUnavailable, null, "Service unavailable");
+
+                return new PaymentIntentResult
+                {
+                    PaymentIntentId = "pi_test",
+                    Status = "succeeded"
+                };
+            });
+
+        var gateway = new ResilientPaymentGateway(_innerGateway, _logger);
+
+        var result = await gateway.CreatePaymentIntentAsync(
+            100m, "usd", new Dictionary<string, string>());
+
+        result.PaymentIntentId.Should().Be("pi_test");
+        callCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreatePaymentIntent_ThrowsAfterMaxRetries()
+    {
+        _innerGateway.CreatePaymentIntentAsync(
+            Arg.Any<decimal>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>())
+            .ThrowsAsyncForAnyArgs(new StripeException(HttpStatusCode.ServiceUnavailable, null, "Service unavailable"));
+
+        var gateway = new ResilientPaymentGateway(_innerGateway, _logger);
+
+        var act = () => gateway.CreatePaymentIntentAsync(
+            100m, "usd", new Dictionary<string, string>());
+
+        await act.Should().ThrowAsync<StripeException>();
+    }
+
+    [Fact]
+    public async Task CreatePaymentIntent_DoesNotRetryOnNonTransientError()
+    {
+        var callCount = 0;
+        _innerGateway.CreatePaymentIntentAsync(
+            Arg.Any<decimal>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>())
+            .ThrowsAsyncForAnyArgs(callInfo =>
+            {
+                callCount++;
+                return new StripeException(HttpStatusCode.BadRequest, null, "Invalid card");
+            });
+
+        var gateway = new ResilientPaymentGateway(_innerGateway, _logger);
+
+        var act = () => gateway.CreatePaymentIntentAsync(
+            100m, "usd", new Dictionary<string, string>());
+
+        await act.Should().ThrowAsync<StripeException>();
+        callCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateRefund_RetriesOnTransientStripeError()
+    {
+        var callCount = 0;
+        _innerGateway.CreateRefundAsync(Arg.Any<string>(), Arg.Any<decimal>())
+            .ReturnsForAnyArgs(callInfo =>
+            {
+                callCount++;
+                if (callCount <= 1)
+                    throw new StripeException(HttpStatusCode.TooManyRequests, null, "Rate limited");
+
+                return new RefundResult
+                {
+                    RefundId = "re_test",
+                    Status = "succeeded"
+                };
+            });
+
+        var gateway = new ResilientPaymentGateway(_innerGateway, _logger);
+
+        var result = await gateway.CreateRefundAsync("pi_test", 50m);
+
+        result.RefundId.Should().Be("re_test");
+        callCount.Should().Be(2);
+    }
+}

--- a/payment-service/Payment.Application/Payment.Application.csproj
+++ b/payment-service/Payment.Application/Payment.Application.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Polly" Version="8.5.0" />
     <PackageReference Include="Stripe.net" Version="46.0.0" />
   </ItemGroup>
 

--- a/payment-service/Payment.Application/Services/ResilientPaymentGateway.cs
+++ b/payment-service/Payment.Application/Services/ResilientPaymentGateway.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Retry;
+using Stripe;
+
+namespace Payment.Application.Services
+{
+    public class ResilientPaymentGateway : IPaymentGateway
+    {
+        private readonly IPaymentGateway _inner;
+        private readonly ILogger<ResilientPaymentGateway> _logger;
+        private readonly ResiliencePipeline _pipeline;
+
+        public ResilientPaymentGateway(
+            IPaymentGateway inner,
+            ILogger<ResilientPaymentGateway> logger)
+        {
+            _inner = inner;
+            _logger = logger;
+
+            _pipeline = new ResiliencePipelineBuilder()
+                .AddRetry(new RetryStrategyOptions
+                {
+                    MaxRetryAttempts = 3,
+                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromMilliseconds(500),
+                    ShouldHandle = new PredicateBuilder().Handle<StripeException>(ex =>
+                        ex.HttpStatusCode is
+                            System.Net.HttpStatusCode.TooManyRequests or
+                            System.Net.HttpStatusCode.ServiceUnavailable or
+                            System.Net.HttpStatusCode.GatewayTimeout or
+                            System.Net.HttpStatusCode.RequestTimeout),
+                    OnRetry = args =>
+                    {
+                        _logger.LogWarning(
+                            args.Outcome.Exception,
+                            "Stripe call failed, retrying (attempt {AttemptNumber}/{MaxRetries})",
+                            args.AttemptNumber,
+                            3);
+                        return ValueTask.CompletedTask;
+                    }
+                })
+                .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+                {
+                    FailureRatio = 0.5,
+                    SamplingDuration = TimeSpan.FromSeconds(30),
+                    MinimumThroughput = 5,
+                    BreakDuration = TimeSpan.FromSeconds(30),
+                    ShouldHandle = new PredicateBuilder().Handle<StripeException>(),
+                    OnOpened = args =>
+                    {
+                        _logger.LogError("Circuit breaker opened for Stripe calls");
+                        return ValueTask.CompletedTask;
+                    },
+                    OnClosed = args =>
+                    {
+                        _logger.LogInformation("Circuit breaker closed for Stripe calls");
+                        return ValueTask.CompletedTask;
+                    }
+                })
+                .AddTimeout(TimeSpan.FromSeconds(10))
+                .Build();
+        }
+
+        public async Task<PaymentIntentResult> CreatePaymentIntentAsync(
+            decimal amount, string currency, Dictionary<string, string> metadata)
+        {
+            return await _pipeline.ExecuteAsync(async ct =>
+                await _inner.CreatePaymentIntentAsync(amount, currency, metadata));
+        }
+
+        public async Task<RefundResult> CreateRefundAsync(string paymentIntentId, decimal amount)
+        {
+            return await _pipeline.ExecuteAsync(async ct =>
+                await _inner.CreateRefundAsync(paymentIntentId, amount));
+        }
+    }
+}

--- a/payment-service/Payment.Application/Services/StripePaymentGateway.cs
+++ b/payment-service/Payment.Application/Services/StripePaymentGateway.cs
@@ -14,7 +14,7 @@ namespace Payment.Application.Services
             _logger = logger;
         }
 
-        public async Task<PaymentIntentResult> CreatePaymentIntentAsync(decimal amount, string currency, Dictionary<string, string> metadata)
+        public virtual async Task<PaymentIntentResult> CreatePaymentIntentAsync(decimal amount, string currency, Dictionary<string, string> metadata)
         {
             var options = new PaymentIntentCreateOptions
             {
@@ -42,7 +42,7 @@ namespace Payment.Application.Services
             };
         }
 
-        public async Task<RefundResult> CreateRefundAsync(string paymentIntentId, decimal amount)
+        public virtual async Task<RefundResult> CreateRefundAsync(string paymentIntentId, decimal amount)
         {
             var options = new RefundCreateOptions
             {

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -5,6 +5,7 @@ using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Payment.Application;
 using Payment.Application.Commands;
@@ -61,7 +62,11 @@ try
         });
     });
 
-    builder.Services.AddScoped<IPaymentGateway, StripePaymentGateway>();
+    builder.Services.AddScoped<StripePaymentGateway>();
+    builder.Services.AddScoped<IPaymentGateway>(sp =>
+        new ResilientPaymentGateway(
+            sp.GetRequiredService<StripePaymentGateway>(),
+            sp.GetRequiredService<ILogger<ResilientPaymentGateway>>()));
 
     builder.Services.AddMediatR(cfg =>
     {

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -48,6 +48,12 @@ public static class DependencyInjection
                     h.Password(password);
                 });
 
+                cfg.UseMessageRetry(r => r.Exponential(
+                    retryLimit: 3,
+                    minInterval: TimeSpan.FromMilliseconds(500),
+                    maxInterval: TimeSpan.FromSeconds(10),
+                    intervalDelta: TimeSpan.FromMilliseconds(500)));
+
                 cfg.ConfigureEndpoints(context);
             });
         });


### PR DESCRIPTION
Closes #37

## Summary
- Added `ResilientPaymentGateway` decorator wrapping `StripePaymentGateway` with Polly v8 retry (3 attempts, exponential backoff for transient HTTP errors), circuit breaker (50% failure ratio, 30s break), and 10s timeout
- Added MassTransit `UseMessageRetry` with exponential backoff in shared infrastructure for all consumers
- Unit tests covering retry on transient errors, no retry on non-transient errors, and max retry exhaustion

## Test plan
- [x] All 14 payment unit tests pass (including 4 new resilience tests)
- [x] Full solution builds clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)