### PR TITLE
Add MassTransit error handling and dead-letter queues

### DIFF
--- a/payment-service/Payment.Application.Tests/Consumers/ProcessPaymentFaultConsumerTests.cs
+++ b/payment-service/Payment.Application.Tests/Consumers/ProcessPaymentFaultConsumerTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using Ecommerce.Events.Order.Messages;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Payment.Application.Consumers;
+
+namespace Payment.Application.Tests.Consumers;
+
+public class ProcessPaymentFaultConsumerTests
+{
+    [Fact]
+    public async Task Consume_LogsCriticalOnPermanentFailure()
+    {
+        var logger = Substitute.For<ILogger<ProcessPaymentFaultConsumer>>();
+        var consumer = new ProcessPaymentFaultConsumer(logger);
+
+        var orderId = Guid.NewGuid();
+        var fault = new FaultMessage<ProcessPayment>
+        {
+            Message = new ProcessPayment
+            {
+                OrderId = orderId,
+                Amount = 99.99m,
+                CustomerId = "cust-1"
+            },
+            FaultedMessageId = Guid.NewGuid(),
+            Exceptions = new[]
+            {
+                new FaultExceptionInfo("System.Exception", "Stripe timeout", "", null)
+            }
+        };
+
+        var context = Substitute.For<ConsumeContext<Fault<ProcessPayment>>>();
+        context.Message.Returns(fault);
+
+        await consumer.Consume(context);
+
+        logger.ReceivedWithAnyArgs(1).LogCritical(default, default(Exception), default, default);
+    }
+
+    private class FaultMessage<T> : Fault<T> where T : class
+    {
+        public Guid FaultId { get; set; } = Guid.NewGuid();
+        public Guid? FaultedMessageId { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+        public ExceptionInfo[] Exceptions { get; set; } = Array.Empty<ExceptionInfo>();
+        public HostInfo Host { get; set; }
+        public T Message { get; set; }
+        public string[] FaultMessageTypes { get; set; } = Array.Empty<string>();
+    }
+
+    private class FaultExceptionInfo : ExceptionInfo
+    {
+        public FaultExceptionInfo(string exceptionType, string message, string stackTrace, ExceptionInfo innerException)
+        {
+            ExceptionType = exceptionType;
+            Message = message;
+            StackTrace = stackTrace;
+            InnerException = innerException;
+        }
+
+        public string ExceptionType { get; }
+        public ExceptionInfo InnerException { get; }
+        public string Message { get; }
+        public string Source { get; } = "";
+        public string StackTrace { get; }
+        public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
+    }
+}

--- a/payment-service/Payment.Application/Consumers/ProcessPaymentFaultConsumer.cs
+++ b/payment-service/Payment.Application/Consumers/ProcessPaymentFaultConsumer.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Ecommerce.Events.Order.Messages;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Payment.Application.Consumers
+{
+    public class ProcessPaymentFaultConsumer : IConsumer<Fault<ProcessPayment>>
+    {
+        private readonly ILogger<ProcessPaymentFaultConsumer> _logger;
+
+        public ProcessPaymentFaultConsumer(ILogger<ProcessPaymentFaultConsumer> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Consume(ConsumeContext<Fault<ProcessPayment>> context)
+        {
+            var orderId = context.Message.Message.OrderId;
+            var exceptions = context.Message.Exceptions;
+
+            _logger.LogCritical(
+                "Payment processing permanently failed for order {OrderId} after all retries. " +
+                "Exceptions: {Exceptions}. MessageId: {MessageId}",
+                orderId,
+                string.Join("; ", exceptions.Select(e => $"{e.ExceptionType}: {e.Message}")),
+                context.Message.FaultedMessageId);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/payment-service/Payment.Application/Consumers/RefundPaymentFaultConsumer.cs
+++ b/payment-service/Payment.Application/Consumers/RefundPaymentFaultConsumer.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Ecommerce.Events.Order.Messages;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Payment.Application.Consumers
+{
+    public class RefundPaymentFaultConsumer : IConsumer<Fault<RefundPayment>>
+    {
+        private readonly ILogger<RefundPaymentFaultConsumer> _logger;
+
+        public RefundPaymentFaultConsumer(ILogger<RefundPaymentFaultConsumer> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Consume(ConsumeContext<Fault<RefundPayment>> context)
+        {
+            var orderId = context.Message.Message.OrderId;
+            var exceptions = context.Message.Exceptions;
+
+            _logger.LogCritical(
+                "Refund processing permanently failed for order {OrderId} after all retries. " +
+                "Exceptions: {Exceptions}. MessageId: {MessageId}",
+                orderId,
+                string.Join("; ", exceptions.Select(e => $"{e.ExceptionType}: {e.Message}")),
+                context.Message.FaultedMessageId);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -54,6 +54,8 @@ try
     {
         bus.AddConsumer<ProcessPaymentConsumer>();
         bus.AddConsumer<RefundPaymentConsumer>();
+        bus.AddConsumer<ProcessPaymentFaultConsumer>();
+        bus.AddConsumer<RefundPaymentFaultConsumer>();
 
         bus.AddEntityFrameworkOutbox<PaymentDbContext>(o =>
         {

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Ecommerce.Shared.Infrastructure.Authentication;
 using Ecommerce.Shared.Infrastructure.Cors;
 using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.Logging;
+using Ecommerce.Shared.Infrastructure.Messaging;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -28,6 +29,8 @@ public static class DependencyInjection
         IConfiguration configuration,
         Action<IBusRegistrationConfigurator> configureBus = null)
     {
+        services.AddSingleton<FaultLoggingObserver>();
+
         services.AddMassTransit(bus =>
         {
             configureBus?.Invoke(bus);
@@ -48,11 +51,19 @@ public static class DependencyInjection
                     h.Password(password);
                 });
 
+                cfg.UseDelayedRedelivery(r => r.Intervals(
+                    TimeSpan.FromSeconds(5),
+                    TimeSpan.FromSeconds(30),
+                    TimeSpan.FromMinutes(2)));
+
                 cfg.UseMessageRetry(r => r.Exponential(
                     retryLimit: 3,
                     minInterval: TimeSpan.FromMilliseconds(500),
                     maxInterval: TimeSpan.FromSeconds(10),
                     intervalDelta: TimeSpan.FromMilliseconds(500)));
+
+                cfg.ConnectConsumeObserver(
+                    context.GetRequiredService<FaultLoggingObserver>());
 
                 cfg.ConfigureEndpoints(context);
             });

--- a/shared/Ecommerce.Shared.Infrastructure/Messaging/FaultLoggingObserver.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Messaging/FaultLoggingObserver.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Ecommerce.Shared.Infrastructure.Messaging;
+
+public class FaultLoggingObserver : IConsumeObserver
+{
+    private readonly ILogger<FaultLoggingObserver> _logger;
+
+    public FaultLoggingObserver(ILogger<FaultLoggingObserver> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PreConsume<T>(ConsumeContext<T> context) where T : class
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task PostConsume<T>(ConsumeContext<T> context) where T : class
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task ConsumeFault<T>(ConsumeContext<T> context, Exception exception) where T : class
+    {
+        _logger.LogError(
+            exception,
+            "Consumer fault on {MessageType} (MessageId: {MessageId}, RetryAttempt: {RetryAttempt})",
+            typeof(T).Name,
+            context.MessageId,
+            context.GetRetryAttempt());
+
+        return Task.CompletedTask;
+    }
+}

--- a/stock-service/Stock.Application/Consumers/ReleaseStockFaultConsumer.cs
+++ b/stock-service/Stock.Application/Consumers/ReleaseStockFaultConsumer.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Ecommerce.Events.Order.Messages;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Stock.Application.Consumers
+{
+    public class ReleaseStockFaultConsumer : IConsumer<Fault<ReleaseStock>>
+    {
+        private readonly ILogger<ReleaseStockFaultConsumer> _logger;
+
+        public ReleaseStockFaultConsumer(ILogger<ReleaseStockFaultConsumer> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Consume(ConsumeContext<Fault<ReleaseStock>> context)
+        {
+            var orderId = context.Message.Message.OrderId;
+            var exceptions = context.Message.Exceptions;
+
+            _logger.LogCritical(
+                "Stock release permanently failed for order {OrderId} after all retries. " +
+                "Exceptions: {Exceptions}. MessageId: {MessageId}",
+                orderId,
+                string.Join("; ", exceptions.Select(e => $"{e.ExceptionType}: {e.Message}")),
+                context.Message.FaultedMessageId);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/stock-service/Stock.Application/Consumers/ReserveStockFaultConsumer.cs
+++ b/stock-service/Stock.Application/Consumers/ReserveStockFaultConsumer.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Ecommerce.Events.Order.Messages;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Stock.Application.Consumers
+{
+    public class ReserveStockFaultConsumer : IConsumer<Fault<ReserveStock>>
+    {
+        private readonly ILogger<ReserveStockFaultConsumer> _logger;
+
+        public ReserveStockFaultConsumer(ILogger<ReserveStockFaultConsumer> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Consume(ConsumeContext<Fault<ReserveStock>> context)
+        {
+            var orderId = context.Message.Message.OrderId;
+            var exceptions = context.Message.Exceptions;
+
+            _logger.LogCritical(
+                "Stock reservation permanently failed for order {OrderId} after all retries. " +
+                "Exceptions: {Exceptions}. MessageId: {MessageId}",
+                orderId,
+                string.Join("; ", exceptions.Select(e => $"{e.ExceptionType}: {e.Message}")),
+                context.Message.FaultedMessageId);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -50,6 +50,8 @@ try
         bus.AddConsumer<ReserveStockConsumer>();
         bus.AddConsumer<ReleaseStockConsumer>();
         bus.AddConsumer<ProductCreatedConsumer>();
+        bus.AddConsumer<ReserveStockFaultConsumer>();
+        bus.AddConsumer<ReleaseStockFaultConsumer>();
 
         bus.AddEntityFrameworkOutbox<StockDbContext>(o =>
         {


### PR DESCRIPTION
Closes #38

## Summary
- Added `UseDelayedRedelivery` with 3 escalating intervals (5s, 30s, 2min) as a second-level retry layer before messages go to error queues
- Created `FaultLoggingObserver` (`IConsumeObserver`) in shared infrastructure for centralized fault logging across all consumers
- Added fault consumers (`IConsumer<Fault<T>>`) for `ProcessPayment`, `RefundPayment`, `ReserveStock`, and `ReleaseStock` that log critical when messages permanently fail
- MassTransit automatically creates `_error` and `_skipped` queues visible in RabbitMQ management UI

## Retry flow
1. **Immediate retry** (existing): 3 attempts with exponential backoff (500ms–10s)
2. **Delayed redelivery** (new): 3 redeliveries at 5s, 30s, 2min intervals
3. **Error queue**: Message moved to `_error` queue after all retries exhausted
4. **Fault consumer**: Logs critical alert for permanent failures

## Test plan
- [x] All 15 payment unit tests pass (including fault consumer test)
- [x] All 9 stock unit tests pass
- [x] Full solution builds clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)