### PR TITLE
Add Prometheus metrics and Grafana dashboards

### DIFF
--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -75,6 +75,7 @@ try
     app.MapGrpcService<CartGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,38 @@ services:
         condition: service_healthy
 
   # ── Dev tools (profile: tools) ───────────────────
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    profiles: ["tools"]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./tools/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=7d"
+    networks:
+      - ecommerce-network
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    profiles: ["tools"]
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./tools/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./tools/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - ecommerce-network
+
   pgadmin:
     image: dpage/pgadmin4
     profiles: ["tools"]
@@ -255,6 +287,8 @@ services:
 volumes:
   postgres_data:
   seq_data:
+  prometheus_data:
+  grafana_data:
 
 networks:
   ecommerce-network:

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -141,6 +141,7 @@ try
     app.MapGrpcService<OrderGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -144,6 +144,7 @@ try
     app.MapGrpcService<PaymentGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -124,6 +124,7 @@ try
     app.MapGrpcService<ProductGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -208,6 +209,15 @@ public static class DependencyInjection
                     {
                         options.Endpoint = new Uri(otlpEndpoint);
                     });
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddMeter("MassTransit")
+                    .AddPrometheusExporter();
             });
 
         return services;

--- a/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
+++ b/shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -134,6 +134,7 @@ try
     app.MapGrpcService<StockGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }

--- a/tools/grafana/dashboards/ecommerce-overview.json
+++ b/tools/grafana/dashboards/ecommerce-overview.json
@@ -1,0 +1,151 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Request Rate by Service",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count[5m])) by (job)",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate by Service (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m])) by (job)",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "title": "Request Latency P95 by Service",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, job))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "title": "Request Latency P50 by Service",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, job))",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "title": "MassTransit Consumer Message Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "msg/s" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(massTransit_receive_total[5m])) by (job)",
+          "legendFormat": "{{job}} - received"
+        },
+        {
+          "expr": "sum(rate(massTransit_consume_total[5m])) by (job)",
+          "legendFormat": "{{job}} - consumed"
+        }
+      ]
+    },
+    {
+      "title": "MassTransit Consumer Failure Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "msg/s" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(massTransit_receive_fault_total[5m])) by (job)",
+          "legendFormat": "{{job}} - faults"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Requests by Status Code",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count[5m])) by (http_response_status_code)",
+          "legendFormat": "{{http_response_status_code}}"
+        }
+      ]
+    },
+    {
+      "title": ".NET Runtime GC Collections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": { "unit": "ops" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(process_runtime_dotnet_gc_collections_count[5m])) by (job, generation)",
+          "legendFormat": "{{job}} gen{{generation}}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["ecommerce"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Ecommerce Overview",
+  "uid": "ecommerce-overview",
+  "version": 1
+}

--- a/tools/grafana/provisioning/dashboards/dashboards.yml
+++ b/tools/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Ecommerce"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/tools/grafana/provisioning/datasources/prometheus.yml
+++ b/tools/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/tools/prometheus/prometheus.yml
+++ b/tools/prometheus/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "product-service"
+    static_configs:
+      - targets: ["product:8080"]
+
+  - job_name: "order-service"
+    static_configs:
+      - targets: ["order:8080"]
+
+  - job_name: "stock-service"
+    static_configs:
+      - targets: ["stock:8080"]
+
+  - job_name: "user-service"
+    static_configs:
+      - targets: ["user:8080"]
+
+  - job_name: "payment-service"
+    static_configs:
+      - targets: ["payment:8080"]
+
+  - job_name: "cart-service"
+    static_configs:
+      - targets: ["cart:8080"]

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -118,6 +118,7 @@ try
     app.MapGrpcService<UserGrpcService>();
     app.MapControllers();
     app.MapHealthChecks("/health");
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
     app.Run();
 }


### PR DESCRIPTION
Closes #41

## Summary
- Added OpenTelemetry Prometheus exporter (`OpenTelemetry.Exporter.Prometheus.AspNetCore`) and runtime instrumentation to shared infrastructure
- All 6 services now expose Prometheus metrics at `/metrics` (request rate, latency, error rates, .NET runtime metrics, MassTransit consumer metrics)
- Added Prometheus and Grafana to `docker-compose.yml` under `tools` profile (`docker compose --profile tools up`)
- Created auto-provisioned Grafana dashboard with 8 panels: request rate, error rate, P95/P50 latency, MassTransit consumer throughput/failures, HTTP status codes, .NET GC collections

## Test plan
- [x] All tests pass across all services
- [x] Full solution builds clean
- [ ] CI pipeline passes
- [ ] `docker compose --profile tools up` starts Prometheus (port 9090) and Grafana (port 3000, admin/admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)