### PR TITLE
Add input sanitization and request size limits

### DIFF
--- a/cart-service/Cart.Service/Program.cs
+++ b/cart-service/Cart.Service/Program.cs
@@ -32,10 +32,12 @@ try
     builder.Services.AddSharedInfrastructure(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Cart.Service");
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(AddToCartCommand).Assembly);
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(AddToCartCommand).Assembly);

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -37,6 +37,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Order.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
@@ -69,6 +70,7 @@ try
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(PlaceOrderCommand).Assembly);
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(PlaceOrderCommand).Assembly);

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -40,6 +40,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Payment.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
@@ -73,6 +74,7 @@ try
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(RefundPaymentCommand).Assembly);
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(RefundPaymentCommand).Assembly);

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -43,6 +43,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Product.Service");
     builder.Services.AddIdempotency(builder.Configuration);
     builder.Services.Configure<CacheSettings>(
@@ -52,6 +53,7 @@ try
     {
         cfg.RegisterServicesFromAssembly(typeof(CreateProductCommand).Assembly);
         cfg.AddOpenBehavior(typeof(CachingBehavior<,>));
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(CreateProductCommand).Assembly);

--- a/shared/Ecommerce.Shared.Infrastructure.Tests/Validation/InputSanitizationBehaviorTests.cs
+++ b/shared/Ecommerce.Shared.Infrastructure.Tests/Validation/InputSanitizationBehaviorTests.cs
@@ -1,0 +1,107 @@
+using Ecommerce.Shared.Infrastructure.Validation;
+using FluentAssertions;
+using MediatR;
+
+namespace Ecommerce.Shared.Infrastructure.Tests;
+
+public class InputSanitizationBehaviorTests
+{
+    private readonly InputSanitizationBehavior<TestCommand, TestResponse> _behavior = new();
+
+    [Fact]
+    public async Task Handle_HtmlInStringProperty_EncodesIt()
+    {
+        var command = new TestCommand { Name = "<script>alert('xss')</script>" };
+
+        await _behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Name.Should().Be("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    }
+
+    [Fact]
+    public async Task Handle_PlainText_RemainsUnchanged()
+    {
+        var command = new TestCommand { Name = "Normal Product Name" };
+
+        await _behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Name.Should().Be("Normal Product Name");
+    }
+
+    [Fact]
+    public async Task Handle_TrimsWhitespace()
+    {
+        var command = new TestCommand { Name = "  padded  " };
+
+        await _behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Name.Should().Be("padded");
+    }
+
+    [Fact]
+    public async Task Handle_NullString_RemainsNull()
+    {
+        var command = new TestCommand { Name = null };
+
+        await _behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NestedObject_SanitizesNestedStrings()
+    {
+        var command = new TestCommandWithNested
+        {
+            Detail = new TestDetail { Description = "<b>bold</b>" }
+        };
+
+        var behavior = new InputSanitizationBehavior<TestCommandWithNested, TestResponse>();
+
+        await behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Detail.Description.Should().Be("&lt;b&gt;bold&lt;/b&gt;");
+    }
+
+    [Fact]
+    public async Task Handle_AmpersandAndQuotes_AreEncoded()
+    {
+        var command = new TestCommand { Name = "A & B \"quoted\"" };
+
+        await _behavior.Handle(command, () => Task.FromResult(new TestResponse()), CancellationToken.None);
+
+        command.Name.Should().Be("A &amp; B &quot;quoted&quot;");
+    }
+
+    [Fact]
+    public async Task Handle_CallsNext()
+    {
+        var command = new TestCommand { Name = "test" };
+        var nextCalled = false;
+
+        await _behavior.Handle(command, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new TestResponse());
+        }, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    public class TestCommand : IRequest<TestResponse>
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestCommandWithNested : IRequest<TestResponse>
+    {
+        public TestDetail Detail { get; set; }
+    }
+
+    public class TestDetail
+    {
+        public string Description { get; set; }
+    }
+
+    public class TestResponse { }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/DependencyInjection.cs
@@ -10,10 +10,12 @@ using Ecommerce.Shared.Infrastructure.Idempotency;
 using Ecommerce.Shared.Infrastructure.Logging;
 using Ecommerce.Shared.Infrastructure.Messaging;
 using Ecommerce.Shared.Infrastructure.RateLimiting;
+using Ecommerce.Shared.Infrastructure.Validation;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
@@ -257,6 +259,21 @@ public static class DependencyInjection
                         .WithHeaders(corsSettings.AllowedHeaders);
                 }
             });
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddRequestSizeLimits(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var settings = configuration.GetSection("RequestSizeLimits").Get<RequestSizeLimitSettings>()
+                       ?? new RequestSizeLimitSettings();
+
+        services.Configure<KestrelServerOptions>(options =>
+        {
+            options.Limits.MaxRequestBodySize = settings.MaxRequestBodySizeBytes;
         });
 
         return services;

--- a/shared/Ecommerce.Shared.Infrastructure/Validation/InputSanitizationBehavior.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Validation/InputSanitizationBehavior.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+
+namespace Ecommerce.Shared.Infrastructure.Validation;
+
+public class InputSanitizationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        SanitizeStrings(request);
+        return next();
+    }
+
+    private static void SanitizeStrings(object obj)
+    {
+        if (obj == null) return;
+
+        var type = obj.GetType();
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || !property.CanWrite)
+                continue;
+
+            if (property.PropertyType == typeof(string))
+            {
+                var value = (string)property.GetValue(obj);
+                if (value != null)
+                {
+                    var sanitized = WebUtility.HtmlEncode(value.Trim());
+                    property.SetValue(obj, sanitized);
+                }
+            }
+            else if (property.PropertyType.IsClass
+                     && property.PropertyType != typeof(string)
+                     && !property.PropertyType.IsArray
+                     && property.PropertyType.Namespace != null
+                     && !property.PropertyType.Namespace.StartsWith("System"))
+            {
+                var nested = property.GetValue(obj);
+                if (nested != null)
+                    SanitizeStrings(nested);
+            }
+        }
+    }
+}

--- a/shared/Ecommerce.Shared.Infrastructure/Validation/RequestSizeLimitSettings.cs
+++ b/shared/Ecommerce.Shared.Infrastructure/Validation/RequestSizeLimitSettings.cs
@@ -1,0 +1,6 @@
+namespace Ecommerce.Shared.Infrastructure.Validation;
+
+public class RequestSizeLimitSettings
+{
+    public long MaxRequestBodySizeBytes { get; set; } = 1_048_576; // 1 MB default
+}

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -35,6 +35,7 @@ try
     builder.Services.AddJwtAuthentication(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "Stock.Service");
     builder.Services.AddIdempotency(builder.Configuration);
 
@@ -63,6 +64,7 @@ try
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(UpdateStockCommand).Assembly);
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(UpdateStockCommand).Assembly);

--- a/user-service/User.Application/Validators/ChangePasswordCommandValidator.cs
+++ b/user-service/User.Application/Validators/ChangePasswordCommandValidator.cs
@@ -8,11 +8,13 @@ namespace User.Application.Validators
         public ChangePasswordCommandValidator()
         {
             RuleFor(x => x.Request.CurrentPassword)
-                .NotEmpty().WithMessage("Current password is required");
+                .NotEmpty().WithMessage("Current password is required")
+                .MaximumLength(128);
 
             RuleFor(x => x.Request.NewPassword)
                 .NotEmpty().WithMessage("New password is required")
-                .MinimumLength(8).WithMessage("New password must be at least 8 characters");
+                .MinimumLength(8).WithMessage("New password must be at least 8 characters")
+                .MaximumLength(128);
         }
     }
 }

--- a/user-service/User.Application/Validators/LoginCommandValidator.cs
+++ b/user-service/User.Application/Validators/LoginCommandValidator.cs
@@ -9,10 +9,12 @@ namespace User.Application.Validators
         {
             RuleFor(x => x.Request.Email)
                 .NotEmpty().WithMessage("Email is required")
+                .MaximumLength(254)
                 .EmailAddress().WithMessage("Invalid email format");
 
             RuleFor(x => x.Request.Password)
-                .NotEmpty().WithMessage("Password is required");
+                .NotEmpty().WithMessage("Password is required")
+                .MaximumLength(128);
         }
     }
 }

--- a/user-service/User.Application/Validators/RegisterCommandValidator.cs
+++ b/user-service/User.Application/Validators/RegisterCommandValidator.cs
@@ -9,11 +9,13 @@ namespace User.Application.Validators
         {
             RuleFor(x => x.Request.Email)
                 .NotEmpty().WithMessage("Email is required")
+                .MaximumLength(254)
                 .EmailAddress().WithMessage("Invalid email format");
 
             RuleFor(x => x.Request.Password)
                 .NotEmpty().WithMessage("Password is required")
-                .MinimumLength(8).WithMessage("Password must be at least 8 characters");
+                .MinimumLength(8).WithMessage("Password must be at least 8 characters")
+                .MaximumLength(128);
 
             RuleFor(x => x.Request.FirstName)
                 .NotEmpty().WithMessage("First name is required")

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -42,6 +42,7 @@ try
     builder.Services.AddCorsConfiguration(builder.Configuration);
     builder.Services.AddRateLimiting(builder.Configuration);
     builder.Services.AddRequestResponseLogging(builder.Configuration);
+    builder.Services.AddRequestSizeLimits(builder.Configuration);
     builder.Services.AddOpenTelemetryTracing(builder.Configuration, "User.Service");
     builder.Services.AddJwtAuthentication(builder.Configuration);
 
@@ -50,6 +51,7 @@ try
     builder.Services.AddMediatR(cfg =>
     {
         cfg.RegisterServicesFromAssembly(typeof(RegisterCommand).Assembly);
+        cfg.AddOpenBehavior(typeof(InputSanitizationBehavior<,>));
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(RegisterCommand).Assembly);


### PR DESCRIPTION
Closes #61

## Summary
- Added `InputSanitizationBehavior` MediatR pipeline behavior that HTML-encodes and trims all string properties on incoming requests, preventing stored XSS
- Added configurable Kestrel request body size limits (default 1MB, configurable via `RequestSizeLimits` config section) — oversized requests return 413
- Added missing `MaximumLength` constraints to user validators (email: 254, passwords: 128)
- Registered sanitization behavior in all 6 services, running before validation

## Test plan
- [x] 7 new sanitization unit tests pass (HTML encoding, trimming, null handling, nested objects)
- [x] All 13 shared infra tests pass
- [x] Full solution builds clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)