### PR TITLE
Update AutoMapper to 16.1.1 across all services

### DIFF
--- a/order-service/Order.Application.Tests/MapperProfileTests.cs
+++ b/order-service/Order.Application.Tests/MapperProfileTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 using Order.Application;
 
 namespace Order.Application.Tests;
@@ -8,7 +9,9 @@ public class MapperProfileTests
     [Fact]
     public void AutoMapper_Configuration_ShouldBeValid()
     {
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         config.AssertConfigurationIsValid();
     }
 }

--- a/order-service/Order.Application/Order.Application.csproj
+++ b/order-service/Order.Application/Order.Application.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/order-service/Order.Service/Order.Service.csproj
+++ b/order-service/Order.Service/Order.Service.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/order-service/Order.Service/Program.cs
+++ b/order-service/Order.Service/Program.cs
@@ -54,7 +54,7 @@ try
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(PlaceOrderCommand).Assembly);
-    builder.Services.AddAutoMapper(typeof(Order.Application.MapperProfile).Assembly);
+    builder.Services.AddAutoMapper(cfg => { }, typeof(Order.Application.MapperProfile).Assembly);
 
     builder.Services.AddProductGrpcClient(builder.Configuration);
 

--- a/payment-service/Payment.Application.Tests/MapperProfileTests.cs
+++ b/payment-service/Payment.Application.Tests/MapperProfileTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 using Payment.Application;
 
 namespace Payment.Application.Tests;
@@ -8,7 +9,9 @@ public class MapperProfileTests
     [Fact]
     public void AutoMapper_Configuration_ShouldBeValid()
     {
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         config.AssertConfigurationIsValid();
     }
 }

--- a/payment-service/Payment.Application.Tests/Queries/GetPaymentByOrderQueryTests.cs
+++ b/payment-service/Payment.Application.Tests/Queries/GetPaymentByOrderQueryTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Payment.Application;
 using Payment.Application.Queries;
 
@@ -21,7 +22,9 @@ public class GetPaymentByOrderQueryTests
             .Options;
         _dbContext = new PaymentDbContext(options);
 
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         _mapper = config.CreateMapper();
     }
 

--- a/payment-service/Payment.Application/Payment.Application.csproj
+++ b/payment-service/Payment.Application/Payment.Application.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/payment-service/Payment.Service/Payment.Service.csproj
+++ b/payment-service/Payment.Service/Payment.Service.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/payment-service/Payment.Service/Program.cs
+++ b/payment-service/Payment.Service/Program.cs
@@ -60,7 +60,7 @@ try
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(RefundPaymentCommand).Assembly);
-    builder.Services.AddAutoMapper(typeof(Payment.Application.MapperProfile).Assembly);
+    builder.Services.AddAutoMapper(cfg => { }, typeof(Payment.Application.MapperProfile).Assembly);
 
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("PaymentDb")!, name: "postgresql");

--- a/product-service/Product.Application.Tests/Commands/CreateProductCommandTests.cs
+++ b/product-service/Product.Application.Tests/Commands/CreateProductCommandTests.cs
@@ -4,6 +4,7 @@ using Ecommerce.Model.Product.Response;
 using FluentAssertions;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Product.Application;
 using Product.Application.Caching;
@@ -25,7 +26,9 @@ public class CreateProductCommandTests
             .Options;
         _dbContext = new ProductDbContext(options);
 
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         _mapper = config.CreateMapper();
 
         _publishEndpoint = Substitute.For<IPublishEndpoint>();

--- a/product-service/Product.Application.Tests/MapperProfileTests.cs
+++ b/product-service/Product.Application.Tests/MapperProfileTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 using Product.Application;
 
 namespace Product.Application.Tests;
@@ -8,7 +9,9 @@ public class MapperProfileTests
     [Fact]
     public void AutoMapper_Configuration_ShouldBeValid()
     {
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         config.AssertConfigurationIsValid();
     }
 }

--- a/product-service/Product.Application.Tests/Queries/GetProductQueryTests.cs
+++ b/product-service/Product.Application.Tests/Queries/GetProductQueryTests.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Product.Application;
 using Product.Application.Queries;
 
@@ -18,7 +19,9 @@ public class GetProductQueryTests
             .Options;
         _dbContext = new ProductDbContext(options);
 
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         _mapper = config.CreateMapper();
     }
 

--- a/product-service/Product.Application/Product.Application.csproj
+++ b/product-service/Product.Application/Product.Application.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/product-service/Product.Service/Product.Service.csproj
+++ b/product-service/Product.Service/Product.Service.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.Elasticsearch" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />

--- a/product-service/Product.Service/Program.cs
+++ b/product-service/Product.Service/Program.cs
@@ -46,7 +46,7 @@ try
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(CreateProductCommand).Assembly);
-    builder.Services.AddAutoMapper(typeof(MapperProfile).Assembly);
+    builder.Services.AddAutoMapper(cfg => { }, typeof(MapperProfile).Assembly);
 
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("ProductDb")!, name: "postgresql")

--- a/stock-service/Stock.Application.Tests/Commands/UpdateStockCommandTests.cs
+++ b/stock-service/Stock.Application.Tests/Commands/UpdateStockCommandTests.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Stock.Application;
 using Stock.Application.Commands;
 using Stock.Application.Entities;
@@ -19,7 +20,9 @@ public class UpdateStockCommandTests
             .Options;
         _dbContext = new StockDbContext(options);
 
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         _mapper = config.CreateMapper();
     }
 

--- a/stock-service/Stock.Application.Tests/MapperProfileTests.cs
+++ b/stock-service/Stock.Application.Tests/MapperProfileTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 using Stock.Application;
 
 namespace Stock.Application.Tests;
@@ -8,7 +9,9 @@ public class MapperProfileTests
     [Fact]
     public void AutoMapper_Configuration_ShouldBeValid()
     {
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         config.AssertConfigurationIsValid();
     }
 }

--- a/stock-service/Stock.Application.Tests/Queries/GetStockQueryTests.cs
+++ b/stock-service/Stock.Application.Tests/Queries/GetStockQueryTests.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Stock.Application;
 using Stock.Application.Entities;
 using Stock.Application.Queries;
@@ -19,7 +20,9 @@ public class GetStockQueryTests
             .Options;
         _dbContext = new StockDbContext(options);
 
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+        var expr = new MapperConfigurationExpression();
+        expr.AddProfile<MapperProfile>();
+        var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
         _mapper = config.CreateMapper();
     }
 

--- a/stock-service/Stock.Application/Stock.Application.csproj
+++ b/stock-service/Stock.Application/Stock.Application.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/stock-service/Stock.Service/Program.cs
+++ b/stock-service/Stock.Service/Program.cs
@@ -50,7 +50,7 @@ try
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(UpdateStockCommand).Assembly);
-    builder.Services.AddAutoMapper(typeof(Stock.Application.MapperProfile).Assembly);
+    builder.Services.AddAutoMapper(cfg => { }, typeof(Stock.Application.MapperProfile).Assembly);
 
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("StockDb")!, name: "postgresql");

--- a/stock-service/Stock.Service/Stock.Service.csproj
+++ b/stock-service/Stock.Service/Stock.Service.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/user-service/User.Application.Tests/MapperProfileTests.cs
+++ b/user-service/User.Application.Tests/MapperProfileTests.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace User.Application.Tests
 {
@@ -8,7 +9,9 @@ namespace User.Application.Tests
         [Fact]
         public void AutoMapper_Configuration_ShouldBeValid()
         {
-            var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperProfile>());
+            var expr = new MapperConfigurationExpression();
+            expr.AddProfile<MapperProfile>();
+            var config = new MapperConfiguration(expr, NullLoggerFactory.Instance);
             var act = () => config.AssertConfigurationIsValid();
             act.Should().NotThrow();
         }

--- a/user-service/User.Application/User.Application.csproj
+++ b/user-service/User.Application/User.Application.csproj
@@ -7,14 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/user-service/User.Service/Program.cs
+++ b/user-service/User.Service/Program.cs
@@ -38,7 +38,7 @@ try
         cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
     });
     builder.Services.AddValidatorsFromAssembly(typeof(RegisterCommand).Assembly);
-    builder.Services.AddAutoMapper(typeof(MapperProfile).Assembly);
+    builder.Services.AddAutoMapper(cfg => { }, typeof(MapperProfile).Assembly);
 
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("UserDb")!, name: "postgresql");

--- a/user-service/User.Service/User.Service.csproj
+++ b/user-service/User.Service/User.Service.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.5" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">


### PR DESCRIPTION
## Summary
- PR #80 only updated AutoMapper in cart-service. This completes the upgrade from 13.0.1 to 16.1.1 for all remaining services (product, order, payment, stock, user)
- Applies the required build fix: `AddAutoMapper(typeof(...).Assembly)` → `AddAutoMapper(cfg => { }, typeof(...).Assembly)` in Program.cs files
- Updates test files to use the new `MapperConfiguration(expr, NullLoggerFactory.Instance)` API
- Bumps `Microsoft.IdentityModel.Tokens` and `System.IdentityModel.Tokens.Jwt` in user-service to resolve transitive dependency conflicts
- Adds `Microsoft.Extensions.Logging.Abstractions 10.0.0` to Application projects (required by AutoMapper 16.1.1)

## Test plan
- [x] Solution builds with 0 errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)