### PR TITLE
[Feature] Add gRPC write endpoints and GraphQL mutations (#116)

### DIFF
--- a/cart-service/Cart.Service/Services/CartGrpcService.cs
+++ b/cart-service/Cart.Service/Services/CartGrpcService.cs
@@ -1,3 +1,5 @@
+using Cart.Application.Commands;
+using Cart.Application.DTOs;
 using Cart.Application.Queries;
 using Ecommerce.Shared.Protos;
 using Grpc.Core;
@@ -21,6 +23,53 @@ public class CartGrpcService : CartGrpc.CartGrpcBase
         if (result is null)
             throw new RpcException(new Status(StatusCode.NotFound, $"Cart {request.CartId} not found"));
 
+        return MapToReply(result);
+    }
+
+    public override async Task<CartReply> AddToCart(AddToCartGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(
+            new AddToCartCommand(request.CartId, request.ProductId, request.Quantity),
+            context.CancellationToken);
+
+        return MapToReply(result);
+    }
+
+    public override async Task<CartReply> UpdateCartItemQuantity(UpdateCartItemQuantityGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(
+            new UpdateQuantityCommand(request.CartId, request.ProductId, request.Quantity),
+            context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Cart item not found"));
+
+        return MapToReply(result);
+    }
+
+    public override async Task<CartReply> RemoveFromCart(RemoveFromCartGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(
+            new RemoveFromCartCommand(request.CartId, request.ProductId),
+            context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Cart item not found"));
+
+        return MapToReply(result);
+    }
+
+    public override async Task<ClearCartGrpcReply> ClearCart(ClearCartGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(
+            new ClearCartCommand(request.CartId),
+            context.CancellationToken);
+
+        return new ClearCartGrpcReply { Success = result };
+    }
+
+    private static CartReply MapToReply(CartDto result)
+    {
         var reply = new CartReply
         {
             Id = result.Id,

--- a/graphql-api/GraphQL.Api/Types/MutationType.cs
+++ b/graphql-api/GraphQL.Api/Types/MutationType.cs
@@ -1,21 +1,236 @@
+using System.Security.Claims;
+using Ecommerce.Shared.Protos;
 using HotChocolate.Authorization;
 
 namespace GraphQL.Api.Types;
 
-/// <summary>
-/// Mutations forward to backend services via their REST APIs.
-/// The GraphQL gateway is read-heavy by design — writes go through the existing
-/// REST endpoints on each service which handle validation, events, and sagas.
-/// This type acts as a placeholder for future write operations once gRPC write
-/// endpoints are added to the backend services.
-/// </summary>
 [Authorize]
 public class Mutation
 {
-    /// <summary>
-    /// Placeholder mutation — the backend services currently expose write operations
-    /// via REST only. Once gRPC write endpoints are added (createProduct, placeOrder, etc.),
-    /// they will be wired here.
-    /// </summary>
-    public string Ping() => "pong";
+    // ── Products ──────────────────────────────────────
+
+    public async Task<Product> CreateProduct(
+        string name,
+        string description,
+        string category,
+        decimal price,
+        ProductGrpc.ProductGrpcClient client)
+    {
+        var reply = await client.CreateProductAsync(new CreateProductGrpcRequest
+        {
+            Name = name,
+            Description = description,
+            Category = category,
+            Price = price.ToString()
+        });
+
+        return MapProduct(reply);
+    }
+
+    public async Task<Product> UpdateProduct(
+        long id,
+        string name,
+        string description,
+        string category,
+        decimal price,
+        ProductGrpc.ProductGrpcClient client)
+    {
+        var reply = await client.UpdateProductAsync(new UpdateProductGrpcRequest
+        {
+            Id = id,
+            Name = name,
+            Description = description,
+            Category = category,
+            Price = price.ToString()
+        });
+
+        return MapProduct(reply);
+    }
+
+    public async Task<bool> DeleteProduct(
+        long id,
+        ProductGrpc.ProductGrpcClient client)
+    {
+        var reply = await client.DeleteProductAsync(new DeleteProductGrpcRequest { Id = id });
+        return reply.Success;
+    }
+
+    // ── Orders ───────────────────────────────────────
+
+    public async Task<Order> PlaceOrder(
+        List<OrderItemInput> items,
+        ClaimsPrincipal claimsPrincipal,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var customerId = claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier) ?? "";
+
+        var request = new PlaceOrderGrpcRequest { CustomerId = customerId };
+        foreach (var item in items)
+        {
+            request.Items.Add(new OrderLineItemGrpc
+            {
+                ProductId = item.ProductId,
+                ProductName = item.ProductName,
+                Quantity = item.Quantity,
+                UnitPrice = item.UnitPrice.ToString()
+            });
+        }
+
+        var reply = await client.PlaceOrderAsync(request);
+        return MapOrder(reply);
+    }
+
+    public async Task<bool> CancelOrder(
+        string orderId,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.CancelOrderAsync(new OrderActionRequest { OrderId = orderId });
+        return reply.Success;
+    }
+
+    public async Task<bool> ShipOrder(
+        string orderId,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.ShipOrderAsync(new OrderActionRequest { OrderId = orderId });
+        return reply.Success;
+    }
+
+    public async Task<bool> DeliverOrder(
+        string orderId,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.DeliverOrderAsync(new OrderActionRequest { OrderId = orderId });
+        return reply.Success;
+    }
+
+    public async Task<bool> ReturnOrder(
+        string orderId,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.ReturnOrderAsync(new OrderActionRequest { OrderId = orderId });
+        return reply.Success;
+    }
+
+    // ── Stock ────────────────────────────────────────
+
+    public async Task<StockLevel> UpdateStock(
+        long productId,
+        int quantity,
+        StockGrpc.StockGrpcClient client)
+    {
+        var reply = await client.UpdateStockAsync(new UpdateStockGrpcRequest
+        {
+            ProductId = productId,
+            Quantity = quantity
+        });
+
+        return new StockLevel
+        {
+            ProductId = reply.ProductId,
+            AvailableQuantity = reply.AvailableQuantity,
+            ReservedQuantity = reply.ReservedQuantity
+        };
+    }
+
+    // ── Cart ─────────────────────────────────────────
+
+    public async Task<Cart> AddToCart(
+        string cartId,
+        long productId,
+        int quantity,
+        CartGrpc.CartGrpcClient client)
+    {
+        var reply = await client.AddToCartAsync(new AddToCartGrpcRequest
+        {
+            CartId = cartId,
+            ProductId = productId,
+            Quantity = quantity
+        });
+
+        return MapCart(reply);
+    }
+
+    public async Task<Cart> UpdateCartItemQuantity(
+        string cartId,
+        long productId,
+        int quantity,
+        CartGrpc.CartGrpcClient client)
+    {
+        var reply = await client.UpdateCartItemQuantityAsync(new UpdateCartItemQuantityGrpcRequest
+        {
+            CartId = cartId,
+            ProductId = productId,
+            Quantity = quantity
+        });
+
+        return MapCart(reply);
+    }
+
+    public async Task<Cart> RemoveFromCart(
+        string cartId,
+        long productId,
+        CartGrpc.CartGrpcClient client)
+    {
+        var reply = await client.RemoveFromCartAsync(new RemoveFromCartGrpcRequest
+        {
+            CartId = cartId,
+            ProductId = productId
+        });
+
+        return MapCart(reply);
+    }
+
+    public async Task<bool> ClearCart(
+        string cartId,
+        CartGrpc.CartGrpcClient client)
+    {
+        var reply = await client.ClearCartAsync(new ClearCartGrpcRequest { CartId = cartId });
+        return reply.Success;
+    }
+
+    // ── Helpers ──────────────────────────────────────
+
+    private static Product MapProduct(ProductReply reply) => new()
+    {
+        Id = reply.Id,
+        Name = reply.Name,
+        Description = reply.Description,
+        Category = reply.Category,
+        Price = decimal.TryParse(reply.Price, out var p) ? p : 0
+    };
+
+    private static Order MapOrder(OrderReply reply) => new()
+    {
+        OrderId = reply.OrderId,
+        CustomerId = reply.CustomerId,
+        Status = reply.Status,
+        TotalAmount = decimal.TryParse(reply.TotalAmount, out var a) ? a : 0,
+        ItemsJson = reply.ItemsJson,
+        CreatedAt = reply.CreatedAt,
+        UpdatedAt = reply.UpdatedAt
+    };
+
+    private static Cart MapCart(CartReply reply) => new()
+    {
+        Id = reply.Id,
+        TotalPrice = decimal.TryParse(reply.TotalPrice, out var t) ? t : 0,
+        LastModifiedAt = reply.LastModifiedAt,
+        Items = reply.Items.Select(i => new CartItem
+        {
+            ProductId = i.ProductId,
+            ProductName = i.ProductName,
+            Quantity = i.Quantity,
+            UnitPrice = decimal.TryParse(i.UnitPrice, out var u) ? u : 0,
+            LineTotal = decimal.TryParse(i.LineTotal, out var l) ? l : 0
+        }).ToList()
+    };
+}
+
+public class OrderItemInput
+{
+    public long ProductId { get; set; }
+    public string ProductName { get; set; } = default!;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
 }

--- a/order-service/Order.Service/Services/OrderGrpcService.cs
+++ b/order-service/Order.Service/Services/OrderGrpcService.cs
@@ -1,6 +1,9 @@
+using Ecommerce.Model.Order.Request;
+using Ecommerce.Model.Order.Response;
 using Ecommerce.Shared.Protos;
 using Grpc.Core;
 using MediatR;
+using Order.Application.Commands;
 using Order.Application.Queries;
 
 namespace Order.Service.Services;
@@ -24,15 +27,70 @@ public class OrderGrpcService : OrderGrpc.OrderGrpcBase
         if (result is null)
             throw new RpcException(new Status(StatusCode.NotFound, $"Order {request.OrderId} not found"));
 
-        return new OrderReply
-        {
-            OrderId = result.OrderId.ToString(),
-            CustomerId = result.CustomerId ?? string.Empty,
-            Status = result.Status ?? string.Empty,
-            TotalAmount = result.TotalAmount.ToString(),
-            ItemsJson = result.ItemsJson ?? string.Empty,
-            CreatedAt = result.CreatedAt.ToString("O"),
-            UpdatedAt = result.UpdatedAt?.ToString("O") ?? string.Empty
-        };
+        return MapToReply(result);
     }
+
+    public override async Task<OrderReply> PlaceOrder(PlaceOrderGrpcRequest request, ServerCallContext context)
+    {
+        var orderRequest = new PlaceOrderRequest
+        {
+            CustomerId = request.CustomerId,
+            Items = request.Items.Select(i => new OrderLineItem
+            {
+                ProductId = i.ProductId,
+                ProductName = i.ProductName,
+                Quantity = i.Quantity,
+                UnitPrice = decimal.TryParse(i.UnitPrice, out var p) ? p : 0
+            }).ToList()
+        };
+
+        var result = await _mediator.Send(new PlaceOrderCommand(orderRequest), context.CancellationToken);
+        return MapToReply(result);
+    }
+
+    public override async Task<OrderActionReply> CancelOrder(OrderActionRequest request, ServerCallContext context)
+    {
+        var orderId = ParseOrderId(request.OrderId);
+        var result = await _mediator.Send(new CancelOrderCommand(orderId), context.CancellationToken);
+        return new OrderActionReply { Success = result };
+    }
+
+    public override async Task<OrderActionReply> ShipOrder(OrderActionRequest request, ServerCallContext context)
+    {
+        var orderId = ParseOrderId(request.OrderId);
+        var result = await _mediator.Send(new ShipOrderCommand(orderId), context.CancellationToken);
+        return new OrderActionReply { Success = result };
+    }
+
+    public override async Task<OrderActionReply> DeliverOrder(OrderActionRequest request, ServerCallContext context)
+    {
+        var orderId = ParseOrderId(request.OrderId);
+        var result = await _mediator.Send(new DeliverOrderCommand(orderId), context.CancellationToken);
+        return new OrderActionReply { Success = result };
+    }
+
+    public override async Task<OrderActionReply> ReturnOrder(OrderActionRequest request, ServerCallContext context)
+    {
+        var orderId = ParseOrderId(request.OrderId);
+        var result = await _mediator.Send(new ReturnOrderCommand(orderId), context.CancellationToken);
+        return new OrderActionReply { Success = result };
+    }
+
+    private static Guid ParseOrderId(string orderId)
+    {
+        if (!Guid.TryParse(orderId, out var parsed))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid order ID format"));
+        return parsed;
+    }
+
+    private static OrderReply MapToReply(OrderResponse result) => new()
+    {
+        OrderId = result.OrderId.ToString(),
+        CustomerId = result.CustomerId ?? string.Empty,
+        Status = result.Status ?? string.Empty,
+        TotalAmount = result.TotalAmount.ToString(),
+        ItemsJson = result.ItemsJson ?? string.Empty,
+        CreatedAt = result.CreatedAt.ToString("O"),
+        UpdatedAt = result.UpdatedAt?.ToString("O") ?? string.Empty
+    };
 }

--- a/product-service/Product.Service/Services/ProductGrpcService.cs
+++ b/product-service/Product.Service/Services/ProductGrpcService.cs
@@ -1,6 +1,8 @@
+using Ecommerce.Model.Product.Request;
 using Ecommerce.Shared.Protos;
 using Grpc.Core;
 using MediatR;
+using Product.Application.Commands;
 using Product.Application.Queries;
 
 namespace Product.Service.Services;
@@ -21,14 +23,7 @@ public class ProductGrpcService : ProductGrpc.ProductGrpcBase
         if (result is null)
             throw new RpcException(new Status(StatusCode.NotFound, $"Product {request.Id} not found"));
 
-        return new ProductReply
-        {
-            Id = result.Id,
-            Name = result.Name ?? string.Empty,
-            Description = result.Description ?? string.Empty,
-            Category = result.Category ?? string.Empty,
-            Price = result.Price.ToString()
-        };
+        return MapToReply(result);
     }
 
     public override async Task<GetProductsReply> GetProducts(GetProductsRequest request, ServerCallContext context)
@@ -48,16 +43,54 @@ public class ProductGrpcService : ProductGrpc.ProductGrpcBase
 
         foreach (var p in result.Items)
         {
-            reply.Products.Add(new ProductReply
-            {
-                Id = p.Id,
-                Name = p.Name ?? string.Empty,
-                Description = p.Description ?? string.Empty,
-                Category = p.Category ?? string.Empty,
-                Price = p.Price.ToString()
-            });
+            reply.Products.Add(MapToReply(p));
         }
 
         return reply;
     }
+
+    public override async Task<ProductReply> CreateProduct(CreateProductGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new CreateProductCommand(new CreateProductRequest
+        {
+            Name = request.Name,
+            Description = request.Description,
+            Category = request.Category,
+            Price = decimal.TryParse(request.Price, out var p) ? p : 0
+        }), context.CancellationToken);
+
+        return MapToReply(result);
+    }
+
+    public override async Task<ProductReply> UpdateProduct(UpdateProductGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new UpdateProductCommand(request.Id, new UpdateProductRequest
+        {
+            Name = request.Name,
+            Description = request.Description,
+            Category = request.Category,
+            Price = decimal.TryParse(request.Price, out var p) ? p : 0
+        }), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Product {request.Id} not found"));
+
+        return MapToReply(result);
+    }
+
+    public override async Task<DeleteProductGrpcReply> DeleteProduct(DeleteProductGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new DeleteProductCommand(request.Id), context.CancellationToken);
+
+        return new DeleteProductGrpcReply { Success = result };
+    }
+
+    private static ProductReply MapToReply(Ecommerce.Model.Product.Response.ProductResponse result) => new()
+    {
+        Id = result.Id,
+        Name = result.Name ?? string.Empty,
+        Description = result.Description ?? string.Empty,
+        Category = result.Category ?? string.Empty,
+        Price = result.Price.ToString()
+    };
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/cart.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/cart.proto
@@ -6,6 +6,10 @@ package ecommerce.cart;
 
 service CartGrpc {
   rpc GetCart (GetCartRequest) returns (CartReply);
+  rpc AddToCart (AddToCartGrpcRequest) returns (CartReply);
+  rpc UpdateCartItemQuantity (UpdateCartItemQuantityGrpcRequest) returns (CartReply);
+  rpc RemoveFromCart (RemoveFromCartGrpcRequest) returns (CartReply);
+  rpc ClearCart (ClearCartGrpcRequest) returns (ClearCartGrpcReply);
 }
 
 message GetCartRequest {
@@ -25,4 +29,29 @@ message CartReply {
   repeated CartItemReply items = 2;
   string total_price = 3;
   string last_modified_at = 4;
+}
+
+message AddToCartGrpcRequest {
+  string cart_id = 1;
+  int64 product_id = 2;
+  int32 quantity = 3;
+}
+
+message UpdateCartItemQuantityGrpcRequest {
+  string cart_id = 1;
+  int64 product_id = 2;
+  int32 quantity = 3;
+}
+
+message RemoveFromCartGrpcRequest {
+  string cart_id = 1;
+  int64 product_id = 2;
+}
+
+message ClearCartGrpcRequest {
+  string cart_id = 1;
+}
+
+message ClearCartGrpcReply {
+  bool success = 1;
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/order.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/order.proto
@@ -6,6 +6,11 @@ package ecommerce.order;
 
 service OrderGrpc {
   rpc GetOrder (GetOrderRequest) returns (OrderReply);
+  rpc PlaceOrder (PlaceOrderGrpcRequest) returns (OrderReply);
+  rpc CancelOrder (OrderActionRequest) returns (OrderActionReply);
+  rpc ShipOrder (OrderActionRequest) returns (OrderActionReply);
+  rpc DeliverOrder (OrderActionRequest) returns (OrderActionReply);
+  rpc ReturnOrder (OrderActionRequest) returns (OrderActionReply);
 }
 
 message GetOrderRequest {
@@ -20,4 +25,24 @@ message OrderReply {
   string items_json = 5;
   string created_at = 6;
   string updated_at = 7;
+}
+
+message PlaceOrderGrpcRequest {
+  string customer_id = 1;
+  repeated OrderLineItemGrpc items = 2;
+}
+
+message OrderLineItemGrpc {
+  int64 product_id = 1;
+  string product_name = 2;
+  int32 quantity = 3;
+  string unit_price = 4;
+}
+
+message OrderActionRequest {
+  string order_id = 1;
+}
+
+message OrderActionReply {
+  bool success = 1;
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/product.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/product.proto
@@ -7,6 +7,9 @@ package ecommerce.product;
 service ProductGrpc {
   rpc GetProduct (GetProductRequest) returns (ProductReply);
   rpc GetProducts (GetProductsRequest) returns (GetProductsReply);
+  rpc CreateProduct (CreateProductGrpcRequest) returns (ProductReply);
+  rpc UpdateProduct (UpdateProductGrpcRequest) returns (ProductReply);
+  rpc DeleteProduct (DeleteProductGrpcRequest) returns (DeleteProductGrpcReply);
 }
 
 message GetProductRequest {
@@ -31,4 +34,27 @@ message GetProductsReply {
   int32 total_count = 2;
   int32 page = 3;
   int32 page_size = 4;
+}
+
+message CreateProductGrpcRequest {
+  string name = 1;
+  string description = 2;
+  string category = 3;
+  string price = 4;
+}
+
+message UpdateProductGrpcRequest {
+  int64 id = 1;
+  string name = 2;
+  string description = 3;
+  string category = 4;
+  string price = 5;
+}
+
+message DeleteProductGrpcRequest {
+  int64 id = 1;
+}
+
+message DeleteProductGrpcReply {
+  bool success = 1;
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/stock.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/stock.proto
@@ -6,6 +6,7 @@ package ecommerce.stock;
 
 service StockGrpc {
   rpc GetStockLevel (GetStockLevelRequest) returns (StockLevelReply);
+  rpc UpdateStock (UpdateStockGrpcRequest) returns (StockLevelReply);
 }
 
 message GetStockLevelRequest {
@@ -16,4 +17,9 @@ message StockLevelReply {
   int64 product_id = 1;
   int32 available_quantity = 2;
   int32 reserved_quantity = 3;
+}
+
+message UpdateStockGrpcRequest {
+  int64 product_id = 1;
+  int32 quantity = 2;
 }

--- a/stock-service/Stock.Service/Services/StockGrpcService.cs
+++ b/stock-service/Stock.Service/Services/StockGrpcService.cs
@@ -1,6 +1,7 @@
 using Ecommerce.Shared.Protos;
 using Grpc.Core;
 using MediatR;
+using Stock.Application.Commands;
 using Stock.Application.Queries;
 
 namespace Stock.Service.Services;
@@ -17,6 +18,23 @@ public class StockGrpcService : StockGrpc.StockGrpcBase
     public override async Task<StockLevelReply> GetStockLevel(GetStockLevelRequest request, ServerCallContext context)
     {
         var result = await _mediator.Send(new GetStockQuery(request.ProductId), context.CancellationToken);
+
+        if (result is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Stock for product {request.ProductId} not found"));
+
+        return new StockLevelReply
+        {
+            ProductId = result.ProductId,
+            AvailableQuantity = result.AvailableQuantity,
+            ReservedQuantity = result.ReservedQuantity
+        };
+    }
+
+    public override async Task<StockLevelReply> UpdateStock(UpdateStockGrpcRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(
+            new UpdateStockCommand(request.ProductId, request.Quantity),
+            context.CancellationToken);
 
         if (result is null)
             throw new RpcException(new Status(StatusCode.NotFound, $"Stock for product {request.ProductId} not found"));


### PR DESCRIPTION
## Summary

Adds write RPCs to all backend gRPC services and wires them into the GraphQL gateway as real mutations, completing the gateway's full read/write capability.

Closes #116

## Changes

### Proto files (13 new RPCs)
| Service | New RPCs |
|---------|----------|
| Product | `CreateProduct`, `UpdateProduct`, `DeleteProduct` |
| Order | `PlaceOrder`, `CancelOrder`, `ShipOrder`, `DeliverOrder`, `ReturnOrder` |
| Stock | `UpdateStock` |
| Cart | `AddToCart`, `UpdateCartItemQuantity`, `RemoveFromCart`, `ClearCart` |

### Backend gRPC service implementations
Each new gRPC method delegates to the existing MediatR command handler — no new business logic, just bridging the transport layer.

### GraphQL mutations
Replaced the placeholder `Mutation` type with 13 real mutations. All mutations require JWT auth via `[Authorize]`. `PlaceOrder` automatically extracts `customerId` from the caller's JWT claims.

## Test plan
- [x] Full solution builds with 0 errors
- [ ] Product mutations: create, update, delete via Banana Cake Pop
- [ ] Order mutations: place order, cancel, ship, deliver, return
- [ ] Stock mutation: update stock quantity
- [ ] Cart mutations: add item, update quantity, remove item, clear
- [ ] All mutations return 401 without JWT token

🤖 Generated with [Claude Code](https://claude.com/claude-code)