### PR TITLE
[Feature] CMS customer management with backend endpoints (#123)

### DIFF
--- a/cms/src/graphql/customers.ts
+++ b/cms/src/graphql/customers.ts
@@ -1,0 +1,73 @@
+import { gql } from '@apollo/client';
+
+export const GET_USERS = gql`
+  query GetUsers($page: Int!, $pageSize: Int!, $search: String) {
+    users(page: $page, pageSize: $pageSize, search: $search) {
+      items {
+        id
+        email
+        firstName
+        lastName
+        phone
+        role
+        createdAt
+      }
+      totalCount
+      page
+      pageSize
+    }
+  }
+`;
+
+export const GET_USER = gql`
+  query GetUser($userId: String!) {
+    user(userId: $userId) {
+      id
+      email
+      firstName
+      lastName
+      phone
+      role
+      createdAt
+    }
+  }
+`;
+
+export const GET_USER_ADDRESSES = gql`
+  query GetUserAddresses($userId: String!) {
+    userAddresses(userId: $userId) {
+      id
+      line1
+      line2
+      city
+      county
+      postCode
+      country
+      isDefault
+    }
+  }
+`;
+
+export const GET_ORDERS_BY_CUSTOMER = gql`
+  query GetOrdersByCustomer($customerId: String!) {
+    ordersByCustomer(customerId: $customerId) {
+      orderId
+      status
+      totalAmount
+      createdAt
+    }
+  }
+`;
+
+export const GET_PAYMENTS_BY_CUSTOMER = gql`
+  query GetPaymentsByCustomer($customerId: String!) {
+    paymentsByCustomer(customerId: $customerId) {
+      id
+      orderId
+      amount
+      currency
+      status
+      createdAt
+    }
+  }
+`;

--- a/cms/src/pages/CustomersPage.tsx
+++ b/cms/src/pages/CustomersPage.tsx
@@ -1,14 +1,337 @@
-import { Typography, Box } from '@mui/material';
+import { useState } from 'react';
+import { useQuery } from '@apollo/client/react';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  TablePagination,
+  TextField,
+  InputAdornment,
+  CircularProgress,
+  Alert,
+  Chip,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Tabs,
+  Tab,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  Visibility as ViewIcon,
+} from '@mui/icons-material';
+import { GET_USERS, GET_USER_ADDRESSES, GET_ORDERS_BY_CUSTOMER, GET_PAYMENTS_BY_CUSTOMER } from '../graphql/customers';
+
+interface User {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  role: string;
+  createdAt: string;
+}
+
+interface Address {
+  id: number;
+  line1: string;
+  line2: string | null;
+  city: string;
+  county: string;
+  postCode: string;
+  country: string;
+  isDefault: boolean;
+}
+
+interface Order {
+  orderId: string;
+  status: string;
+  totalAmount: number;
+  createdAt: string;
+}
+
+interface PaymentRecord {
+  id: number;
+  orderId: string;
+  amount: number;
+  currency: string;
+  status: string;
+  createdAt: string;
+}
+
+function CustomerDetail({ userId, onClose }: { userId: string; onClose: () => void }) {
+  const [tab, setTab] = useState(0);
+
+  const { data: addrData, loading: addrLoading } = useQuery(GET_USER_ADDRESSES, {
+    variables: { userId },
+  });
+  const { data: ordersData, loading: ordersLoading } = useQuery(GET_ORDERS_BY_CUSTOMER, {
+    variables: { customerId: userId },
+  });
+  const { data: paymentsData, loading: paymentsLoading } = useQuery(GET_PAYMENTS_BY_CUSTOMER, {
+    variables: { customerId: userId },
+  });
+
+  const addresses: Address[] = addrData?.userAddresses ?? [];
+  const orders: Order[] = ordersData?.ordersByCustomer ?? [];
+  const payments: PaymentRecord[] = paymentsData?.paymentsByCustomer ?? [];
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Customer Detail</DialogTitle>
+      <DialogContent>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+          <Tab label={`Addresses (${addresses.length})`} />
+          <Tab label={`Orders (${orders.length})`} />
+          <Tab label={`Payments (${payments.length})`} />
+        </Tabs>
+
+        {tab === 0 && (
+          addrLoading ? <CircularProgress /> : addresses.length === 0 ? (
+            <Typography color="text.secondary">No addresses on file.</Typography>
+          ) : (
+            <List disablePadding>
+              {addresses.map((addr) => (
+                <Box key={addr.id}>
+                  <ListItem>
+                    <ListItemText
+                      primary={
+                        <>
+                          {addr.line1}{addr.line2 ? `, ${addr.line2}` : ''}
+                          {addr.isDefault && (
+                            <Chip label="Default" size="small" color="primary" sx={{ ml: 1 }} />
+                          )}
+                        </>
+                      }
+                      secondary={`${addr.city}, ${addr.county ? addr.county + ', ' : ''}${addr.postCode}, ${addr.country}`}
+                    />
+                  </ListItem>
+                  <Divider />
+                </Box>
+              ))}
+            </List>
+          )
+        )}
+
+        {tab === 1 && (
+          ordersLoading ? <CircularProgress /> : orders.length === 0 ? (
+            <Typography color="text.secondary">No orders found.</Typography>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Order ID</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                    <TableCell>Date</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {orders.map((o) => (
+                    <TableRow key={o.orderId} hover>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                        {o.orderId.slice(0, 8)}...
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={o.status}
+                          size="small"
+                          color={
+                            o.status === 'Completed' ? 'success' :
+                            o.status === 'Cancelled' ? 'error' : 'default'
+                          }
+                        />
+                      </TableCell>
+                      <TableCell align="right">${o.totalAmount.toFixed(2)}</TableCell>
+                      <TableCell>{new Date(o.createdAt).toLocaleDateString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )
+        )}
+
+        {tab === 2 && (
+          paymentsLoading ? <CircularProgress /> : payments.length === 0 ? (
+            <Typography color="text.secondary">No payments found.</Typography>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>Order</TableCell>
+                    <TableCell align="right">Amount</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell>Date</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {payments.map((p) => (
+                    <TableRow key={p.id} hover>
+                      <TableCell>{p.id}</TableCell>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                        {p.orderId.slice(0, 8)}...
+                      </TableCell>
+                      <TableCell align="right">
+                        {p.amount.toFixed(2)} {p.currency.toUpperCase()}
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={p.status}
+                          size="small"
+                          color={p.status === 'Succeeded' ? 'success' : 'default'}
+                        />
+                      </TableCell>
+                      <TableCell>{new Date(p.createdAt).toLocaleDateString()}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export default function CustomersPage() {
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [selectedUser, setSelectedUser] = useState<string | null>(null);
+
+  const { data, loading, error } = useQuery(GET_USERS, {
+    variables: { page: page + 1, pageSize, search: search || null },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const users: User[] = data?.users?.items ?? [];
+  const totalCount: number = data?.users?.totalCount ?? 0;
+
+  const handleSearch = () => {
+    setSearch(searchInput);
+    setPage(0);
+  };
+
   return (
     <Box>
-      <Typography variant="h4" gutterBottom>
-        Customers
-      </Typography>
-      <Typography color="text.secondary">
-        Customer management coming soon.
-      </Typography>
+      <Typography variant="h4" sx={{ mb: 3 }}>Customers</Typography>
+
+      <TextField
+        placeholder="Search by name or email..."
+        size="small"
+        value={searchInput}
+        onChange={(e) => setSearchInput(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+        sx={{ mb: 2, width: 350 }}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Failed to load customers: {error.message}
+        </Alert>
+      )}
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Phone</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Joined</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading && !data ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <CircularProgress />
+                </TableCell>
+              </TableRow>
+            ) : users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">No customers found</Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => (
+                <TableRow key={user.id} hover>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight={500}>
+                      {user.firstName} {user.lastName}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>{user.phone || '—'}</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={user.role}
+                      size="small"
+                      color={user.role === 'Admin' ? 'primary' : 'default'}
+                      variant="outlined"
+                    />
+                  </TableCell>
+                  <TableCell>{new Date(user.createdAt).toLocaleDateString()}</TableCell>
+                  <TableCell align="right">
+                    <IconButton
+                      size="small"
+                      onClick={() => setSelectedUser(user.id)}
+                      title="View details"
+                    >
+                      <ViewIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={totalCount}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={pageSize}
+          onRowsPerPageChange={(e) => {
+            setPageSize(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[5, 10, 25, 50]}
+        />
+      </TableContainer>
+
+      {selectedUser && (
+        <CustomerDetail userId={selectedUser} onClose={() => setSelectedUser(null)} />
+      )}
     </Box>
   );
 }

--- a/graphql-api/GraphQL.Api/Types/QueryType.cs
+++ b/graphql-api/GraphQL.Api/Types/QueryType.cs
@@ -164,6 +164,99 @@ public class Query
         }).ToList();
     }
 
+    // ── Admin: Customers ─────────────────────────────
+
+    [Authorize]
+    public async Task<UserConnection> GetUsers(
+        int page,
+        int pageSize,
+        string? search,
+        UserGrpc.UserGrpcClient client)
+    {
+        var reply = await client.GetUsersAsync(new GetUsersRequest
+        {
+            Page = page,
+            PageSize = pageSize,
+            Search = search ?? string.Empty
+        });
+
+        return new UserConnection
+        {
+            Items = reply.Users.Select(u => new User
+            {
+                Id = u.Id,
+                Email = u.Email,
+                FirstName = u.FirstName,
+                LastName = u.LastName,
+                Phone = u.Phone,
+                Role = u.Role,
+                CreatedAt = u.CreatedAt
+            }).ToList(),
+            TotalCount = reply.TotalCount,
+            Page = reply.Page,
+            PageSize = reply.PageSize
+        };
+    }
+
+    [Authorize]
+    public async Task<User?> GetUser(
+        string userId,
+        UserDataLoader loader)
+    {
+        return await loader.LoadAsync(userId);
+    }
+
+    [Authorize]
+    public async Task<List<Address>> GetUserAddresses(
+        string userId,
+        UserGrpc.UserGrpcClient client)
+    {
+        var reply = await client.GetAddressesAsync(new GetAddressesRequest { UserId = userId });
+        return reply.Addresses.Select(a => new Address
+        {
+            Id = a.Id,
+            Line1 = a.Line1,
+            Line2 = a.Line2,
+            City = a.City,
+            County = a.County,
+            PostCode = a.PostCode,
+            Country = a.Country,
+            IsDefault = a.IsDefault
+        }).ToList();
+    }
+
+    [Authorize]
+    public async Task<List<Order>> GetOrdersByCustomer(
+        string customerId,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.GetOrdersByCustomerAsync(
+            new GetOrdersByCustomerRequest { CustomerId = customerId });
+
+        return reply.Orders.Select(MapOrder).ToList();
+    }
+
+    [Authorize]
+    public async Task<List<Payment>> GetPaymentsByCustomer(
+        string customerId,
+        PaymentGrpc.PaymentGrpcClient client)
+    {
+        var reply = await client.GetPaymentsByCustomerAsync(
+            new GetPaymentsByCustomerRequest { CustomerId = customerId });
+
+        return reply.Payments.Select(p => new Payment
+        {
+            Id = p.Id,
+            OrderId = p.OrderId,
+            CustomerId = p.CustomerId,
+            Amount = decimal.TryParse(p.Amount, out var a) ? a : 0,
+            Currency = p.Currency,
+            Status = p.Status,
+            StripePaymentIntentId = p.StripePaymentIntentId,
+            CreatedAt = p.CreatedAt
+        }).ToList();
+    }
+
     // ── Payments ─────────────────────────────────────
 
     [Authorize]
@@ -296,6 +389,14 @@ public class Query
 public class ProductConnection
 {
     public List<Product> Items { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
+public class UserConnection
+{
+    public List<User> Items { get; set; } = [];
     public int TotalCount { get; set; }
     public int Page { get; set; }
     public int PageSize { get; set; }

--- a/order-service/Order.Application/Queries/GetOrdersByCustomerQuery.cs
+++ b/order-service/Order.Application/Queries/GetOrdersByCustomerQuery.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Ecommerce.Model.Order.Response;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Order.Application.Queries
+{
+    public class GetOrdersByCustomerQuery : IRequest<List<OrderResponse>>
+    {
+        public GetOrdersByCustomerQuery(string customerId)
+        {
+            CustomerId = customerId;
+        }
+
+        public string CustomerId { get; }
+    }
+
+    public class GetOrdersByCustomerQueryHandler : IRequestHandler<GetOrdersByCustomerQuery, List<OrderResponse>>
+    {
+        private readonly OrderDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetOrdersByCustomerQueryHandler(OrderDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _mapper = mapper;
+        }
+
+        public async Task<List<OrderResponse>> Handle(GetOrdersByCustomerQuery request, CancellationToken cancellationToken)
+        {
+            var orders = await _dbContext.Orders
+                .AsNoTracking()
+                .Where(o => o.CustomerId == request.CustomerId)
+                .OrderByDescending(o => o.CreatedAt)
+                .ToListAsync(cancellationToken);
+
+            return orders.Select(o => _mapper.Map<OrderResponse>(o)).ToList();
+        }
+    }
+}

--- a/order-service/Order.Service/Services/OrderGrpcService.cs
+++ b/order-service/Order.Service/Services/OrderGrpcService.cs
@@ -30,6 +30,19 @@ public class OrderGrpcService : OrderGrpc.OrderGrpcBase
         return MapToReply(result);
     }
 
+    public override async Task<GetOrdersByCustomerReply> GetOrdersByCustomer(GetOrdersByCustomerRequest request, ServerCallContext context)
+    {
+        var results = await _mediator.Send(new GetOrdersByCustomerQuery(request.CustomerId), context.CancellationToken);
+
+        var reply = new GetOrdersByCustomerReply();
+        foreach (var order in results)
+        {
+            reply.Orders.Add(MapToReply(order));
+        }
+
+        return reply;
+    }
+
     public override async Task<OrderReply> PlaceOrder(PlaceOrderGrpcRequest request, ServerCallContext context)
     {
         var orderRequest = new PlaceOrderRequest

--- a/shared/Ecommerce.Shared.Protos/Protos/order.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/order.proto
@@ -6,6 +6,7 @@ package ecommerce.order;
 
 service OrderGrpc {
   rpc GetOrder (GetOrderRequest) returns (OrderReply);
+  rpc GetOrdersByCustomer (GetOrdersByCustomerRequest) returns (GetOrdersByCustomerReply);
   rpc PlaceOrder (PlaceOrderGrpcRequest) returns (OrderReply);
   rpc CancelOrder (OrderActionRequest) returns (OrderActionReply);
   rpc ShipOrder (OrderActionRequest) returns (OrderActionReply);
@@ -37,6 +38,14 @@ message OrderLineItemGrpc {
   string product_name = 2;
   int32 quantity = 3;
   string unit_price = 4;
+}
+
+message GetOrdersByCustomerRequest {
+  string customer_id = 1;
+}
+
+message GetOrdersByCustomerReply {
+  repeated OrderReply orders = 1;
 }
 
 message OrderActionRequest {

--- a/shared/Ecommerce.Shared.Protos/Protos/user.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/user.proto
@@ -6,6 +6,7 @@ package ecommerce.user;
 
 service UserGrpc {
   rpc GetUser (GetUserRequest) returns (UserReply);
+  rpc GetUsers (GetUsersRequest) returns (GetUsersReply);
   rpc GetAddresses (GetAddressesRequest) returns (GetAddressesReply);
 }
 
@@ -21,6 +22,19 @@ message UserReply {
   string phone = 5;
   string created_at = 6;
   string role = 7;
+}
+
+message GetUsersRequest {
+  int32 page = 1;
+  int32 page_size = 2;
+  string search = 3;
+}
+
+message GetUsersReply {
+  repeated UserReply users = 1;
+  int32 total_count = 2;
+  int32 page = 3;
+  int32 page_size = 4;
 }
 
 message GetAddressesRequest {

--- a/user-service/User.Application/Queries/GetUsersQuery.cs
+++ b/user-service/User.Application/Queries/GetUsersQuery.cs
@@ -1,0 +1,77 @@
+using AutoMapper;
+using Ecommerce.Model.User.Response;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using User.Application.Entities;
+
+namespace User.Application.Queries
+{
+    public class GetUsersQuery : IRequest<GetUsersResult>
+    {
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+        public string Search { get; set; } = string.Empty;
+    }
+
+    public class GetUsersResult
+    {
+        public List<UserResponse> Users { get; set; } = [];
+        public int TotalCount { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+    }
+
+    public class GetUsersQueryHandler : IRequestHandler<GetUsersQuery, GetUsersResult>
+    {
+        private readonly UserDbContext _dbContext;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IMapper _mapper;
+
+        public GetUsersQueryHandler(UserDbContext dbContext, UserManager<ApplicationUser> userManager, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _userManager = userManager;
+            _mapper = mapper;
+        }
+
+        public async Task<GetUsersResult> Handle(GetUsersQuery query, CancellationToken cancellationToken)
+        {
+            var usersQuery = _dbContext.Users.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(query.Search))
+            {
+                var search = query.Search.ToLowerInvariant();
+                usersQuery = usersQuery.Where(u =>
+                    u.Email.ToLower().Contains(search) ||
+                    u.FirstName.ToLower().Contains(search) ||
+                    u.LastName.ToLower().Contains(search));
+            }
+
+            var totalCount = await usersQuery.CountAsync(cancellationToken);
+
+            var users = await usersQuery
+                .OrderByDescending(u => u.CreatedAt)
+                .Skip((query.Page - 1) * query.PageSize)
+                .Take(query.PageSize)
+                .ToListAsync(cancellationToken);
+
+            var responses = new List<UserResponse>();
+            foreach (var user in users)
+            {
+                var response = _mapper.Map<UserResponse>(user);
+                var roles = await _userManager.GetRolesAsync(user);
+                response.Role = roles.FirstOrDefault() ?? "User";
+                responses.Add(response);
+            }
+
+            return new GetUsersResult
+            {
+                Users = responses,
+                TotalCount = totalCount,
+                Page = query.Page,
+                PageSize = query.PageSize
+            };
+        }
+    }
+}

--- a/user-service/User.Service/Services/UserGrpcService.cs
+++ b/user-service/User.Service/Services/UserGrpcService.cs
@@ -36,6 +36,39 @@ public class UserGrpcService : UserGrpc.UserGrpcBase
         };
     }
 
+    public override async Task<GetUsersReply> GetUsers(GetUsersRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetUsersQuery
+        {
+            Page = request.Page > 0 ? request.Page : 1,
+            PageSize = request.PageSize > 0 ? request.PageSize : 20,
+            Search = request.Search
+        }, context.CancellationToken);
+
+        var reply = new GetUsersReply
+        {
+            TotalCount = result.TotalCount,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+
+        foreach (var user in result.Users)
+        {
+            reply.Users.Add(new UserReply
+            {
+                Id = user.Id.ToString(),
+                Email = user.Email ?? string.Empty,
+                FirstName = user.FirstName ?? string.Empty,
+                LastName = user.LastName ?? string.Empty,
+                Phone = user.Phone ?? string.Empty,
+                CreatedAt = user.CreatedAt.ToString("O"),
+                Role = user.Role ?? "User"
+            });
+        }
+
+        return reply;
+    }
+
     public override async Task<GetAddressesReply> GetAddresses(GetAddressesRequest request, ServerCallContext context)
     {
         if (!Guid.TryParse(request.UserId, out var userId))


### PR DESCRIPTION
## Summary
- Add user listing, order-by-customer, and payment-by-customer gRPC endpoints
- Build CMS customer management UI with search, pagination, and detail view

Closes #123

## Changes

### Backend
- **user.proto**: New `GetUsers` RPC with pagination + search
- **User Service**: `GetUsersQuery` handler with email/name search, role resolution
- **order.proto**: New `GetOrdersByCustomer` RPC
- **Order Service**: `GetOrdersByCustomerQuery` handler
- **GraphQL**: 5 new admin queries — `getUsers`, `getUser`, `getUserAddresses`, `getOrdersByCustomer`, `getPaymentsByCustomer`

### Frontend (cms/)
- Customer list page with server-side search and pagination
- Customer detail dialog with 3 tabs:
  - Addresses (with default indicator)
  - Orders (status chips, totals, dates)
  - Payments (amount, currency, status)

## Test plan
- [x] .NET solution builds with 0 errors
- [x] All 109 unit tests pass
- [x] CMS TypeScript compiles and builds
- [ ] Customer list loads with pagination
- [ ] Search filters by name/email
- [ ] Detail dialog shows addresses, orders, payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)