### PR TITLE
[Feature] CMS order management UI (#126)

### DIFF
--- a/cms/src/graphql/orders.ts
+++ b/cms/src/graphql/orders.ts
@@ -1,0 +1,53 @@
+import { gql } from '@apollo/client';
+
+export const GET_ORDERS = gql`
+  query GetOrders($page: Int!, $pageSize: Int!, $status: String) {
+    orders(page: $page, pageSize: $pageSize, status: $status) {
+      items {
+        orderId
+        customerId
+        status
+        totalAmount
+        items {
+          productId
+          quantity
+          unitPrice
+        }
+        customer {
+          firstName
+          lastName
+          email
+        }
+        createdAt
+        updatedAt
+      }
+      totalCount
+      page
+      pageSize
+    }
+  }
+`;
+
+export const CANCEL_ORDER = gql`
+  mutation CancelOrder($orderId: String!) {
+    cancelOrder(orderId: $orderId)
+  }
+`;
+
+export const SHIP_ORDER = gql`
+  mutation ShipOrder($orderId: String!) {
+    shipOrder(orderId: $orderId)
+  }
+`;
+
+export const DELIVER_ORDER = gql`
+  mutation DeliverOrder($orderId: String!) {
+    deliverOrder(orderId: $orderId)
+  }
+`;
+
+export const RETURN_ORDER = gql`
+  mutation ReturnOrder($orderId: String!) {
+    returnOrder(orderId: $orderId)
+  }
+`;

--- a/cms/src/pages/OrdersPage.tsx
+++ b/cms/src/pages/OrdersPage.tsx
@@ -1,14 +1,365 @@
-import { Typography, Box } from '@mui/material';
+import { useState } from 'react';
+import { useQuery, useMutation } from '@apollo/client/react';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  TablePagination,
+  CircularProgress,
+  Alert,
+  Chip,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+} from '@mui/material';
+import {
+  Visibility as ViewIcon,
+  LocalShipping as ShipIcon,
+  CheckCircle as DeliverIcon,
+  Cancel as CancelIcon,
+  Undo as ReturnIcon,
+} from '@mui/icons-material';
+import { GET_ORDERS, CANCEL_ORDER, SHIP_ORDER, DELIVER_ORDER, RETURN_ORDER } from '../graphql/orders';
+
+interface OrderItem {
+  productId: number;
+  quantity: number;
+  unitPrice: number;
+}
+
+interface OrderCustomer {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+interface OrderRecord {
+  orderId: string;
+  customerId: string;
+  status: string;
+  totalAmount: number;
+  items: OrderItem[];
+  customer: OrderCustomer | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const statusColors: Record<string, 'default' | 'info' | 'warning' | 'success' | 'error'> = {
+  Placed: 'info',
+  Processing: 'warning',
+  Shipped: 'warning',
+  Delivered: 'success',
+  Completed: 'success',
+  Cancelled: 'error',
+  Returned: 'error',
+};
+
+const statusFilters = ['', 'Placed', 'Processing', 'Shipped', 'Delivered', 'Completed', 'Cancelled', 'Returned'];
+
+// Which actions are available for each status
+function getActions(status: string): string[] {
+  switch (status) {
+    case 'Placed':
+    case 'Processing':
+      return ['ship', 'cancel'];
+    case 'Shipped':
+      return ['deliver'];
+    case 'Delivered':
+    case 'Completed':
+      return ['return'];
+    default:
+      return [];
+  }
+}
 
 export default function OrdersPage() {
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [statusFilter, setStatusFilter] = useState('');
+
+  const [detailOrder, setDetailOrder] = useState<OrderRecord | null>(null);
+
+  const [confirmAction, setConfirmAction] = useState<{ orderId: string; action: string } | null>(null);
+
+  const { data, loading, error, refetch } = useQuery(GET_ORDERS, {
+    variables: { page: page + 1, pageSize, status: statusFilter || null },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [cancelOrder, { loading: cancelling }] = useMutation(CANCEL_ORDER);
+  const [shipOrder, { loading: shipping }] = useMutation(SHIP_ORDER);
+  const [deliverOrder, { loading: delivering }] = useMutation(DELIVER_ORDER);
+  const [returnOrder, { loading: returning }] = useMutation(RETURN_ORDER);
+
+  const orders: OrderRecord[] = data?.orders?.items ?? [];
+  const totalCount: number = data?.orders?.totalCount ?? 0;
+  const mutating = cancelling || shipping || delivering || returning;
+
+  const executeAction = async () => {
+    if (!confirmAction) return;
+    const { orderId, action } = confirmAction;
+    try {
+      switch (action) {
+        case 'ship': await shipOrder({ variables: { orderId } }); break;
+        case 'deliver': await deliverOrder({ variables: { orderId } }); break;
+        case 'cancel': await cancelOrder({ variables: { orderId } }); break;
+        case 'return': await returnOrder({ variables: { orderId } }); break;
+      }
+      setConfirmAction(null);
+      refetch();
+    } catch (err) {
+      console.error('Action failed:', err);
+    }
+  };
+
+  const actionLabel: Record<string, string> = {
+    ship: 'Ship',
+    deliver: 'Mark Delivered',
+    cancel: 'Cancel',
+    return: 'Return',
+  };
+
   return (
     <Box>
-      <Typography variant="h4" gutterBottom>
-        Orders
-      </Typography>
-      <Typography color="text.secondary">
-        Order management coming soon.
-      </Typography>
+      <Typography variant="h4" sx={{ mb: 3 }}>Orders</Typography>
+
+      <FormControl size="small" sx={{ mb: 2, minWidth: 180 }}>
+        <InputLabel>Filter by status</InputLabel>
+        <Select
+          value={statusFilter}
+          label="Filter by status"
+          onChange={(e) => { setStatusFilter(e.target.value); setPage(0); }}
+        >
+          <MenuItem value="">All statuses</MenuItem>
+          {statusFilters.filter(Boolean).map((s) => (
+            <MenuItem key={s} value={s}>{s}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Failed to load orders: {error.message}
+        </Alert>
+      )}
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Order ID</TableCell>
+              <TableCell>Customer</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell align="right">Total</TableCell>
+              <TableCell>Date</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading && !data ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <CircularProgress />
+                </TableCell>
+              </TableRow>
+            ) : orders.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">No orders found</Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              orders.map((order) => (
+                <TableRow key={order.orderId} hover>
+                  <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                    {order.orderId.slice(0, 8)}...
+                  </TableCell>
+                  <TableCell>
+                    {order.customer ? (
+                      <>
+                        <Typography variant="body2" fontWeight={500}>
+                          {order.customer.firstName} {order.customer.lastName}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {order.customer.email}
+                        </Typography>
+                      </>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        {order.customerId.slice(0, 8)}...
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={order.status}
+                      size="small"
+                      color={statusColors[order.status] ?? 'default'}
+                    />
+                  </TableCell>
+                  <TableCell align="right">${order.totalAmount.toFixed(2)}</TableCell>
+                  <TableCell>{new Date(order.createdAt).toLocaleDateString()}</TableCell>
+                  <TableCell align="right">
+                    <IconButton size="small" onClick={() => setDetailOrder(order)} title="View details">
+                      <ViewIcon fontSize="small" />
+                    </IconButton>
+                    {getActions(order.status).includes('ship') && (
+                      <IconButton
+                        size="small"
+                        color="primary"
+                        onClick={() => setConfirmAction({ orderId: order.orderId, action: 'ship' })}
+                        title="Ship"
+                      >
+                        <ShipIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    {getActions(order.status).includes('deliver') && (
+                      <IconButton
+                        size="small"
+                        color="success"
+                        onClick={() => setConfirmAction({ orderId: order.orderId, action: 'deliver' })}
+                        title="Mark Delivered"
+                      >
+                        <DeliverIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    {getActions(order.status).includes('cancel') && (
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => setConfirmAction({ orderId: order.orderId, action: 'cancel' })}
+                        title="Cancel"
+                      >
+                        <CancelIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    {getActions(order.status).includes('return') && (
+                      <IconButton
+                        size="small"
+                        color="warning"
+                        onClick={() => setConfirmAction({ orderId: order.orderId, action: 'return' })}
+                        title="Return"
+                      >
+                        <ReturnIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={totalCount}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={pageSize}
+          onRowsPerPageChange={(e) => {
+            setPageSize(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[5, 10, 25, 50]}
+        />
+      </TableContainer>
+
+      {/* Order Detail Dialog */}
+      <Dialog open={!!detailOrder} onClose={() => setDetailOrder(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Order {detailOrder?.orderId.slice(0, 8)}...
+          <Chip
+            label={detailOrder?.status}
+            size="small"
+            color={statusColors[detailOrder?.status ?? ''] ?? 'default'}
+            sx={{ ml: 1 }}
+          />
+        </DialogTitle>
+        <DialogContent>
+          {detailOrder && (
+            <>
+              <Typography variant="subtitle2" gutterBottom sx={{ mt: 1 }}>
+                Customer
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                {detailOrder.customer
+                  ? `${detailOrder.customer.firstName} ${detailOrder.customer.lastName} (${detailOrder.customer.email})`
+                  : detailOrder.customerId}
+              </Typography>
+
+              <Typography variant="subtitle2" gutterBottom>
+                Items
+              </Typography>
+              <List disablePadding dense>
+                {detailOrder.items.map((item, i) => (
+                  <Box key={i}>
+                    <ListItem>
+                      <ListItemText
+                        primary={`Product #${item.productId}`}
+                        secondary={`Qty: ${item.quantity} × $${item.unitPrice.toFixed(2)}`}
+                      />
+                      <Typography variant="body2">
+                        ${(item.quantity * item.unitPrice).toFixed(2)}
+                      </Typography>
+                    </ListItem>
+                    <Divider />
+                  </Box>
+                ))}
+              </List>
+
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
+                <Typography variant="subtitle2">Total</Typography>
+                <Typography variant="subtitle2">${detailOrder.totalAmount.toFixed(2)}</Typography>
+              </Box>
+
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+                Created: {new Date(detailOrder.createdAt).toLocaleString()}
+                {detailOrder.updatedAt && (
+                  <> | Updated: {new Date(detailOrder.updatedAt).toLocaleString()}</>
+                )}
+              </Typography>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Action Confirmation Dialog */}
+      <Dialog open={!!confirmAction} onClose={() => setConfirmAction(null)}>
+        <DialogTitle>Confirm Action</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to <strong>{confirmAction?.action}</strong> order{' '}
+            <code>{confirmAction?.orderId.slice(0, 8)}...</code>?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmAction(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color={confirmAction?.action === 'cancel' || confirmAction?.action === 'return' ? 'error' : 'primary'}
+            onClick={executeAction}
+            disabled={mutating}
+          >
+            {mutating ? 'Processing...' : actionLabel[confirmAction?.action ?? '']}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/graphql-api/GraphQL.Api/Types/QueryType.cs
+++ b/graphql-api/GraphQL.Api/Types/QueryType.cs
@@ -113,6 +113,29 @@ public class Query
     // ── Orders ───────────────────────────────────────
 
     [Authorize]
+    public async Task<OrderConnection> GetOrders(
+        int page,
+        int pageSize,
+        string? status,
+        OrderGrpc.OrderGrpcClient client)
+    {
+        var reply = await client.GetOrdersAsync(new GetOrdersRequest
+        {
+            Page = page,
+            PageSize = pageSize,
+            Status = status ?? string.Empty
+        });
+
+        return new OrderConnection
+        {
+            Items = reply.Orders.Select(MapOrder).ToList(),
+            TotalCount = reply.TotalCount,
+            Page = reply.Page,
+            PageSize = reply.PageSize
+        };
+    }
+
+    [Authorize]
     public async Task<Order?> GetOrder(
         string orderId,
         OrderGrpc.OrderGrpcClient client)
@@ -389,6 +412,14 @@ public class Query
 public class ProductConnection
 {
     public List<Product> Items { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
+public class OrderConnection
+{
+    public List<Order> Items { get; set; } = [];
     public int TotalCount { get; set; }
     public int Page { get; set; }
     public int PageSize { get; set; }

--- a/order-service/Order.Application/Queries/GetOrdersQuery.cs
+++ b/order-service/Order.Application/Queries/GetOrdersQuery.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Ecommerce.Model.Order.Response;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Order.Application.Queries
+{
+    public class GetOrdersQuery : IRequest<GetOrdersResult>
+    {
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+        public string Status { get; set; } = string.Empty;
+    }
+
+    public class GetOrdersResult
+    {
+        public List<OrderResponse> Orders { get; set; } = [];
+        public int TotalCount { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+    }
+
+    public class GetOrdersQueryHandler : IRequestHandler<GetOrdersQuery, GetOrdersResult>
+    {
+        private readonly OrderDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetOrdersQueryHandler(OrderDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _mapper = mapper;
+        }
+
+        public async Task<GetOrdersResult> Handle(GetOrdersQuery request, CancellationToken cancellationToken)
+        {
+            var query = _dbContext.Orders.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(request.Status))
+            {
+                query = query.Where(o => o.Status == request.Status);
+            }
+
+            var totalCount = await query.CountAsync(cancellationToken);
+
+            var orders = await query
+                .OrderByDescending(o => o.CreatedAt)
+                .Skip((request.Page - 1) * request.PageSize)
+                .Take(request.PageSize)
+                .ToListAsync(cancellationToken);
+
+            return new GetOrdersResult
+            {
+                Orders = orders.Select(o => _mapper.Map<OrderResponse>(o)).ToList(),
+                TotalCount = totalCount,
+                Page = request.Page,
+                PageSize = request.PageSize
+            };
+        }
+    }
+}

--- a/order-service/Order.Service/Services/OrderGrpcService.cs
+++ b/order-service/Order.Service/Services/OrderGrpcService.cs
@@ -30,6 +30,30 @@ public class OrderGrpcService : OrderGrpc.OrderGrpcBase
         return MapToReply(result);
     }
 
+    public override async Task<GetOrdersReply> GetOrders(GetOrdersRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetOrdersQuery
+        {
+            Page = request.Page > 0 ? request.Page : 1,
+            PageSize = request.PageSize > 0 ? request.PageSize : 20,
+            Status = request.Status
+        }, context.CancellationToken);
+
+        var reply = new GetOrdersReply
+        {
+            TotalCount = result.TotalCount,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+
+        foreach (var order in result.Orders)
+        {
+            reply.Orders.Add(MapToReply(order));
+        }
+
+        return reply;
+    }
+
     public override async Task<GetOrdersByCustomerReply> GetOrdersByCustomer(GetOrdersByCustomerRequest request, ServerCallContext context)
     {
         var results = await _mediator.Send(new GetOrdersByCustomerQuery(request.CustomerId), context.CancellationToken);

--- a/shared/Ecommerce.Shared.Protos/Protos/order.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/order.proto
@@ -6,6 +6,7 @@ package ecommerce.order;
 
 service OrderGrpc {
   rpc GetOrder (GetOrderRequest) returns (OrderReply);
+  rpc GetOrders (GetOrdersRequest) returns (GetOrdersReply);
   rpc GetOrdersByCustomer (GetOrdersByCustomerRequest) returns (GetOrdersByCustomerReply);
   rpc PlaceOrder (PlaceOrderGrpcRequest) returns (OrderReply);
   rpc CancelOrder (OrderActionRequest) returns (OrderActionReply);
@@ -38,6 +39,19 @@ message OrderLineItemGrpc {
   string product_name = 2;
   int32 quantity = 3;
   string unit_price = 4;
+}
+
+message GetOrdersRequest {
+  int32 page = 1;
+  int32 page_size = 2;
+  string status = 3;
+}
+
+message GetOrdersReply {
+  repeated OrderReply orders = 1;
+  int32 total_count = 2;
+  int32 page = 3;
+  int32 page_size = 4;
 }
 
 message GetOrdersByCustomerRequest {


### PR DESCRIPTION
## Summary
- Add paginated order listing with status filter across backend and GraphQL
- Build CMS order management page with status transitions and detail view

Closes #126

## Changes

### Backend
- **order.proto**: New `GetOrders` RPC with pagination + status filter
- **Order Service**: `GetOrdersQuery` handler, `OrderGrpcService.GetOrders`
- **GraphQL**: `getOrders` query with `OrderConnection` type

### Frontend (cms/)
- Order list with status filter dropdown and pagination
- Status chips color-coded by order state
- Order detail dialog (customer, items, totals, timestamps)
- Status transition actions: Ship, Deliver, Cancel, Return
- Confirmation dialogs for all status changes
- Actions shown contextually per order status

## Test plan
- [x] .NET solution builds, all 109 unit tests pass
- [x] CMS TypeScript compiles and builds
- [ ] Order list loads with pagination
- [ ] Status filter works correctly
- [ ] Detail dialog shows full order info
- [ ] Status transitions work with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)