### PR TITLE
Add exchange order auto-creation in Returns service (#140)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,6 +343,8 @@ services:
     env_file: .env.docker
     environment:
       - ConnectionStrings__ReturnDb=Host=pgbouncer;Port=6432;Database=return_db;Username=ecommerce;Password=ecommerce
+      - GrpcClients__OrderService=http://order:8080
+      - GrpcClients__ProductService=http://product:8080
       - OpenTelemetry__OtlpEndpoint=http://jaeger:4317
     healthcheck: *app-healthcheck
     networks:
@@ -351,6 +353,10 @@ services:
       pgbouncer:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      order:
+        condition: service_healthy
+      product:
         condition: service_healthy
 
   audit:

--- a/domain/Ecommerce.Events/Return/ExchangeOrderCreated.cs
+++ b/domain/Ecommerce.Events/Return/ExchangeOrderCreated.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Ecommerce.Events.Return
+{
+    public class ExchangeOrderCreated
+    {
+        public long ReturnRequestId { get; init; }
+        public Guid OriginalOrderId { get; init; }
+        public Guid ExchangeOrderId { get; init; }
+        public string CustomerId { get; init; } = string.Empty;
+        public long ExchangeProductId { get; init; }
+        public int Quantity { get; init; }
+    }
+}

--- a/domain/Ecommerce.Model/Return/Response/ReturnResponse.cs
+++ b/domain/Ecommerce.Model/Return/Response/ReturnResponse.cs
@@ -22,5 +22,8 @@ namespace Ecommerce.Model.Return.Response
         public DateTime? ApprovedAt { get; set; }
         public DateTime? ReceivedAt { get; set; }
         public DateTime? ResolvedAt { get; set; }
+        public long? ExchangeProductId { get; set; }
+        public string ExchangeProductName { get; set; } = string.Empty;
+        public Guid? ExchangeOrderId { get; set; }
     }
 }

--- a/graphql-api/GraphQL.Api/Types/MutationType.cs
+++ b/graphql-api/GraphQL.Api/Types/MutationType.cs
@@ -278,13 +278,17 @@ public class Mutation
         long id,
         string resolution,
         decimal refundAmount,
+        long? exchangeProductId,
+        string? exchangeProductName,
         ReturnsGrpc.ReturnsGrpcClient client)
     {
         var reply = await client.ResolveReturnAsync(new ResolveReturnGrpcRequest
         {
             Id = id,
             Resolution = resolution,
-            RefundAmount = refundAmount.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            RefundAmount = refundAmount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ExchangeProductId = exchangeProductId ?? 0,
+            ExchangeProductName = exchangeProductName ?? string.Empty
         });
 
         return MapReturn(reply);
@@ -773,7 +777,10 @@ public class Mutation
         CreatedAt = r.CreatedAt,
         ApprovedAt = string.IsNullOrEmpty(r.ApprovedAt) ? null : r.ApprovedAt,
         ReceivedAt = string.IsNullOrEmpty(r.ReceivedAt) ? null : r.ReceivedAt,
-        ResolvedAt = string.IsNullOrEmpty(r.ResolvedAt) ? null : r.ResolvedAt
+        ResolvedAt = string.IsNullOrEmpty(r.ResolvedAt) ? null : r.ResolvedAt,
+        ExchangeProductId = r.ExchangeProductId == 0 ? null : r.ExchangeProductId,
+        ExchangeProductName = string.IsNullOrEmpty(r.ExchangeProductName) ? null : r.ExchangeProductName,
+        ExchangeOrderId = string.IsNullOrEmpty(r.ExchangeOrderId) ? null : r.ExchangeOrderId
     };
 
     private static Coupon MapCoupon(CouponReply c) => new()

--- a/graphql-api/GraphQL.Api/Types/QueryType.cs
+++ b/graphql-api/GraphQL.Api/Types/QueryType.cs
@@ -758,7 +758,10 @@ public class Query
         CreatedAt = r.CreatedAt,
         ApprovedAt = string.IsNullOrEmpty(r.ApprovedAt) ? null : r.ApprovedAt,
         ReceivedAt = string.IsNullOrEmpty(r.ReceivedAt) ? null : r.ReceivedAt,
-        ResolvedAt = string.IsNullOrEmpty(r.ResolvedAt) ? null : r.ResolvedAt
+        ResolvedAt = string.IsNullOrEmpty(r.ResolvedAt) ? null : r.ResolvedAt,
+        ExchangeProductId = r.ExchangeProductId == 0 ? null : r.ExchangeProductId,
+        ExchangeProductName = string.IsNullOrEmpty(r.ExchangeProductName) ? null : r.ExchangeProductName,
+        ExchangeOrderId = string.IsNullOrEmpty(r.ExchangeOrderId) ? null : r.ExchangeOrderId
     };
 
     // ── Audit Log ────────────────────────────────────

--- a/graphql-api/GraphQL.Api/Types/ReturnType.cs
+++ b/graphql-api/GraphQL.Api/Types/ReturnType.cs
@@ -20,4 +20,7 @@ public class ReturnRequest
     public string? ApprovedAt { get; set; }
     public string? ReceivedAt { get; set; }
     public string? ResolvedAt { get; set; }
+    public long? ExchangeProductId { get; set; }
+    public string? ExchangeProductName { get; set; }
+    public string? ExchangeOrderId { get; set; }
 }

--- a/return-service/Dockerfile
+++ b/return-service/Dockerfile
@@ -5,6 +5,7 @@ COPY domain/Ecommerce.Events/Ecommerce.Events.csproj domain/Ecommerce.Events/
 COPY domain/Ecommerce.Model/Ecommerce.Model.csproj domain/Ecommerce.Model/
 COPY shared/Ecommerce.Shared.Infrastructure/Ecommerce.Shared.Infrastructure.csproj shared/Ecommerce.Shared.Infrastructure/
 COPY shared/Ecommerce.Shared.Protos/Ecommerce.Shared.Protos.csproj shared/Ecommerce.Shared.Protos/
+COPY shared/Ecommerce.Shared.GrpcClients/Ecommerce.Shared.GrpcClients.csproj shared/Ecommerce.Shared.GrpcClients/
 COPY return-service/Return.Application/Return.Application.csproj return-service/Return.Application/
 COPY return-service/Return.Infrastructure/Return.Infrastructure.csproj return-service/Return.Infrastructure/
 COPY return-service/Return.Service/Return.Service.csproj return-service/Return.Service/

--- a/return-service/Return.Application/Commands/ResolveReturnCommand.cs
+++ b/return-service/Return.Application/Commands/ResolveReturnCommand.cs
@@ -4,9 +4,11 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Ecommerce.Events.Return;
 using Ecommerce.Model.Return.Response;
+using Ecommerce.Shared.Protos;
 using MassTransit;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Return.Application.Policies;
 
 namespace Return.Application.Commands
@@ -16,6 +18,8 @@ namespace Return.Application.Commands
         public long ReturnRequestId { get; set; }
         public string Resolution { get; set; } = string.Empty; // full_refund, partial_refund, exchange
         public decimal RefundAmount { get; set; }
+        public long? ExchangeProductId { get; set; }
+        public string ExchangeProductName { get; set; } = string.Empty;
     }
 
     public class ResolveReturnCommandHandler : IRequestHandler<ResolveReturnCommand, ReturnResponse>
@@ -23,12 +27,24 @@ namespace Return.Application.Commands
         private readonly ReturnDbContext _dbContext;
         private readonly IPublishEndpoint _publishEndpoint;
         private readonly IMapper _mapper;
+        private readonly OrderGrpc.OrderGrpcClient _orderClient;
+        private readonly ProductGrpc.ProductGrpcClient _productClient;
+        private readonly ILogger<ResolveReturnCommandHandler> _logger;
 
-        public ResolveReturnCommandHandler(ReturnDbContext dbContext, IPublishEndpoint publishEndpoint, IMapper mapper)
+        public ResolveReturnCommandHandler(
+            ReturnDbContext dbContext,
+            IPublishEndpoint publishEndpoint,
+            IMapper mapper,
+            OrderGrpc.OrderGrpcClient orderClient,
+            ProductGrpc.ProductGrpcClient productClient,
+            ILogger<ResolveReturnCommandHandler> logger)
         {
             _dbContext = dbContext;
             _publishEndpoint = publishEndpoint;
             _mapper = mapper;
+            _orderClient = orderClient;
+            _productClient = productClient;
+            _logger = logger;
         }
 
         public async Task<ReturnResponse> Handle(ResolveReturnCommand command, CancellationToken cancellationToken)
@@ -49,17 +65,69 @@ namespace Return.Application.Commands
             ret.Status = command.Resolution == "exchange" ? "Exchanged" : "Refunded";
             ret.ResolvedAt = DateTime.UtcNow;
             ret.UpdatedAt = DateTime.UtcNow;
-            await _dbContext.SaveChangesAsync(cancellationToken);
 
-            if (command.Resolution is "full_refund" or "partial_refund")
+            if (command.Resolution == "exchange")
             {
-                await _publishEndpoint.Publish(new RefundRequested
+                var exchangeProductId = command.ExchangeProductId ?? ret.ProductId;
+                var exchangeProductName = command.ExchangeProductName;
+
+                if (string.IsNullOrEmpty(exchangeProductName))
+                {
+                    var product = await _productClient.GetProductAsync(
+                        new GetProductRequest { Id = exchangeProductId },
+                        cancellationToken: cancellationToken);
+                    exchangeProductName = product.Name;
+                }
+
+                var exchangeOrder = await _orderClient.PlaceOrderAsync(new PlaceOrderGrpcRequest
+                {
+                    CustomerId = ret.CustomerId,
+                    Items =
+                    {
+                        new OrderLineItemGrpc
+                        {
+                            ProductId = exchangeProductId,
+                            ProductName = exchangeProductName,
+                            Quantity = ret.Quantity,
+                            UnitPrice = "0.00"
+                        }
+                    }
+                }, cancellationToken: cancellationToken);
+
+                ret.ExchangeProductId = exchangeProductId;
+                ret.ExchangeProductName = exchangeProductName;
+                ret.ExchangeOrderId = Guid.Parse(exchangeOrder.OrderId);
+
+                _logger.LogInformation(
+                    "Exchange order {ExchangeOrderId} created for return {ReturnId}",
+                    exchangeOrder.OrderId, ret.Id);
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
+
+                await _publishEndpoint.Publish(new ExchangeOrderCreated
                 {
                     ReturnRequestId = ret.Id,
-                    OrderId = ret.OrderId,
+                    OriginalOrderId = ret.OrderId,
+                    ExchangeOrderId = Guid.Parse(exchangeOrder.OrderId),
                     CustomerId = ret.CustomerId,
-                    Amount = finalRefund
+                    ExchangeProductId = exchangeProductId,
+                    Quantity = ret.Quantity
                 }, cancellationToken);
+            }
+            else
+            {
+                await _dbContext.SaveChangesAsync(cancellationToken);
+
+                if (command.Resolution is "full_refund" or "partial_refund")
+                {
+                    await _publishEndpoint.Publish(new RefundRequested
+                    {
+                        ReturnRequestId = ret.Id,
+                        OrderId = ret.OrderId,
+                        CustomerId = ret.CustomerId,
+                        Amount = finalRefund
+                    }, cancellationToken);
+                }
             }
 
             return _mapper.Map<ReturnResponse>(ret);

--- a/return-service/Return.Application/Entities/ReturnRequest.cs
+++ b/return-service/Return.Application/Entities/ReturnRequest.cs
@@ -22,6 +22,9 @@ namespace Return.Application.Entities
         public DateTime? ApprovedAt { get; set; }
         public DateTime? ReceivedAt { get; set; }
         public DateTime? ResolvedAt { get; set; }
+        public long? ExchangeProductId { get; set; }
+        public string ExchangeProductName { get; set; } = string.Empty;
+        public Guid? ExchangeOrderId { get; set; }
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     }
 }

--- a/return-service/Return.Application/Return.Application.csproj
+++ b/return-service/Return.Application/Return.Application.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\domain\Ecommerce.Events\Ecommerce.Events.csproj" />
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
     <ProjectReference Include="..\..\shared\Ecommerce.Shared.Infrastructure\Ecommerce.Shared.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
   </ItemGroup>
 
 </Project>

--- a/return-service/Return.Application/ReturnDbContext.cs
+++ b/return-service/Return.Application/ReturnDbContext.cs
@@ -33,6 +33,8 @@ namespace Return.Application
                 entity.Property(e => e.AdminNotes).HasMaxLength(1000);
                 entity.HasIndex(e => e.OrderId);
                 entity.HasIndex(e => e.CustomerId);
+                entity.Property(e => e.ExchangeProductName).HasMaxLength(200);
+                entity.HasIndex(e => e.ExchangeOrderId);
             });
         }
     }

--- a/return-service/Return.Infrastructure/Migrations/20260409213248_AddExchangeOrderFields.Designer.cs
+++ b/return-service/Return.Infrastructure/Migrations/20260409213248_AddExchangeOrderFields.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Return.Application;
@@ -11,9 +12,11 @@ using Return.Application;
 namespace Return.Infrastructure.Migrations
 {
     [DbContext(typeof(ReturnDbContext))]
-    partial class ReturnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409213248_AddExchangeOrderFields")]
+    partial class AddExchangeOrderFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/return-service/Return.Infrastructure/Migrations/20260409213248_AddExchangeOrderFields.cs
+++ b/return-service/Return.Infrastructure/Migrations/20260409213248_AddExchangeOrderFields.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Return.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExchangeOrderFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ExchangeOrderId",
+                table: "ReturnRequests",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ExchangeProductId",
+                table: "ReturnRequests",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExchangeProductName",
+                table: "ReturnRequests",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReturnRequests_ExchangeOrderId",
+                table: "ReturnRequests",
+                column: "ExchangeOrderId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ReturnRequests_ExchangeOrderId",
+                table: "ReturnRequests");
+
+            migrationBuilder.DropColumn(
+                name: "ExchangeOrderId",
+                table: "ReturnRequests");
+
+            migrationBuilder.DropColumn(
+                name: "ExchangeProductId",
+                table: "ReturnRequests");
+
+            migrationBuilder.DropColumn(
+                name: "ExchangeProductName",
+                table: "ReturnRequests");
+        }
+    }
+}

--- a/return-service/Return.Service/Program.cs
+++ b/return-service/Return.Service/Program.cs
@@ -1,3 +1,4 @@
+using Ecommerce.Shared.GrpcClients;
 using Ecommerce.Shared.Infrastructure;
 using Ecommerce.Shared.Infrastructure.Validation;
 using FluentValidation;
@@ -37,6 +38,9 @@ try
     });
     builder.Services.AddValidatorsFromAssembly(typeof(CreateReturnCommand).Assembly);
     builder.Services.AddAutoMapper(cfg => { }, typeof(Return.Application.MapperProfile).Assembly);
+
+    builder.Services.AddOrderGrpcClient(builder.Configuration);
+    builder.Services.AddProductGrpcClient(builder.Configuration);
 
     builder.Services.AddHealthChecks()
         .AddNpgSql(builder.Configuration.GetConnectionString("ReturnDb")!, name: "postgresql");

--- a/return-service/Return.Service/Return.Service.csproj
+++ b/return-service/Return.Service/Return.Service.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\domain\Ecommerce.Model\Ecommerce.Model.csproj" />
     <ProjectReference Include="..\..\shared\Ecommerce.Shared.Protos\Ecommerce.Shared.Protos.csproj" />
+    <ProjectReference Include="..\..\shared\Ecommerce.Shared.GrpcClients\Ecommerce.Shared.GrpcClients.csproj" />
     <ProjectReference Include="..\Return.Infrastructure\Return.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/return-service/Return.Service/Services/ReturnsGrpcService.cs
+++ b/return-service/Return.Service/Services/ReturnsGrpcService.cs
@@ -81,7 +81,9 @@ public class ReturnsGrpcService : ReturnsGrpc.ReturnsGrpcBase
         {
             ReturnRequestId = request.Id,
             Resolution = request.Resolution,
-            RefundAmount = decimal.TryParse(request.RefundAmount, CultureInfo.InvariantCulture, out var a) ? a : 0
+            RefundAmount = decimal.TryParse(request.RefundAmount, CultureInfo.InvariantCulture, out var a) ? a : 0,
+            ExchangeProductId = request.ExchangeProductId == 0 ? null : request.ExchangeProductId,
+            ExchangeProductName = request.ExchangeProductName
         }, context.CancellationToken);
 
         if (result == null)
@@ -108,6 +110,9 @@ public class ReturnsGrpcService : ReturnsGrpc.ReturnsGrpcBase
         CreatedAt = r.CreatedAt.ToString("O"),
         ApprovedAt = r.ApprovedAt?.ToString("O") ?? string.Empty,
         ReceivedAt = r.ReceivedAt?.ToString("O") ?? string.Empty,
-        ResolvedAt = r.ResolvedAt?.ToString("O") ?? string.Empty
+        ResolvedAt = r.ResolvedAt?.ToString("O") ?? string.Empty,
+        ExchangeProductId = r.ExchangeProductId ?? 0,
+        ExchangeProductName = r.ExchangeProductName ?? string.Empty,
+        ExchangeOrderId = r.ExchangeOrderId?.ToString() ?? string.Empty
     };
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/returns.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/returns.proto
@@ -53,6 +53,9 @@ message ReturnReply {
   string approved_at = 16;
   string received_at = 17;
   string resolved_at = 18;
+  int64 exchange_product_id = 19;
+  string exchange_product_name = 20;
+  string exchange_order_id = 21;
 }
 
 message CreateReturnGrpcRequest {
@@ -78,4 +81,6 @@ message ResolveReturnGrpcRequest {
   int64 id = 1;
   string resolution = 2;
   string refund_amount = 3;
+  int64 exchange_product_id = 4;
+  string exchange_product_name = 5;
 }


### PR DESCRIPTION
## Summary
- Auto-creates replacement orders via Order Service gRPC when a return is resolved as "exchange"
- Supports exchange for same product or different variant (pass exchangeProductId)
- Links exchange order back to return via ExchangeOrderId field
- Publishes ExchangeOrderCreated event for downstream consumers
- Wires up Order + Product gRPC clients in Returns service

Closes #140

## Test plan
- [x] Full solution builds with 0 errors
- [x] All existing unit tests pass (no regressions)
- [ ] Resolve a return as "exchange" and verify replacement order is created
- [ ] Verify exchange for different product variant works
- [ ] Check ExchangeOrderId is populated on the return record

🤖 Generated with [Claude Code](https://claude.com/claude-code)