### PR TITLE
Add return shipping label generation and carrier integration (#139)

### DIFF
--- a/domain/Ecommerce.Model/Return/Response/ReturnShipmentResponse.cs
+++ b/domain/Ecommerce.Model/Return/Response/ReturnShipmentResponse.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Ecommerce.Model.Return.Response
+{
+    public class ReturnShipmentResponse
+    {
+        public long Id { get; set; }
+        public long ReturnRequestId { get; set; }
+        public string Carrier { get; set; } = string.Empty;
+        public string TrackingNumber { get; set; } = string.Empty;
+        public string LabelUrl { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string DropOffLocation { get; set; } = string.Empty;
+        public DateTime? ShippedAt { get; set; }
+        public DateTime? DeliveredAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/graphql-api/GraphQL.Api/Types/MutationType.cs
+++ b/graphql-api/GraphQL.Api/Types/MutationType.cs
@@ -294,6 +294,32 @@ public class Mutation
         return MapReturn(reply);
     }
 
+    public async Task<ReturnShipment> GenerateReturnLabel(
+        long returnRequestId,
+        string? carrier,
+        ReturnsGrpc.ReturnsGrpcClient client)
+    {
+        var reply = await client.GenerateReturnLabelAsync(new GenerateReturnLabelRequest
+        {
+            ReturnRequestId = returnRequestId,
+            Carrier = carrier ?? "royal_mail"
+        });
+
+        return MapReturnShipment(reply);
+    }
+
+    public async Task<ReturnShipment> UpdateReturnShipmentStatus(
+        long returnRequestId,
+        ReturnsGrpc.ReturnsGrpcClient client)
+    {
+        var reply = await client.UpdateShipmentStatusAsync(new UpdateShipmentStatusRequest
+        {
+            ReturnRequestId = returnRequestId
+        });
+
+        return MapReturnShipment(reply);
+    }
+
     // ── Stock ────────────────────────────────────────
 
     public async Task<StockLevel> UpdateStock(
@@ -756,6 +782,20 @@ public class Mutation
         Description = t.Description,
         OrderId = string.IsNullOrEmpty(t.OrderId) ? null : t.OrderId,
         CreatedAt = t.CreatedAt
+    };
+
+    private static ReturnShipment MapReturnShipment(ReturnShipmentReply s) => new()
+    {
+        Id = s.Id,
+        ReturnRequestId = s.ReturnRequestId,
+        Carrier = s.Carrier,
+        TrackingNumber = s.TrackingNumber,
+        LabelUrl = s.LabelUrl,
+        Status = s.Status,
+        DropOffLocation = string.IsNullOrEmpty(s.DropOffLocation) ? null : s.DropOffLocation,
+        ShippedAt = string.IsNullOrEmpty(s.ShippedAt) ? null : s.ShippedAt,
+        DeliveredAt = string.IsNullOrEmpty(s.DeliveredAt) ? null : s.DeliveredAt,
+        CreatedAt = s.CreatedAt
     };
 
     private static ReturnRequest MapReturn(ReturnReply r) => new()

--- a/graphql-api/GraphQL.Api/Types/QueryType.cs
+++ b/graphql-api/GraphQL.Api/Types/QueryType.cs
@@ -465,6 +465,15 @@ public class Query
         return reply.Returns.Select(MapReturn).ToList();
     }
 
+    [Authorize]
+    public async Task<ReturnShipment?> GetReturnShipment(
+        long returnRequestId,
+        ReturnsGrpc.ReturnsGrpcClient client)
+    {
+        var reply = await client.GetReturnShipmentAsync(new GetReturnShipmentRequest { ReturnRequestId = returnRequestId });
+        return MapReturnShipment(reply);
+    }
+
     // ── Loyalty ──────────────────────────────────────
 
     [Authorize]
@@ -737,6 +746,20 @@ public class Query
         Description = t.Description,
         OrderId = string.IsNullOrEmpty(t.OrderId) ? null : t.OrderId,
         CreatedAt = t.CreatedAt
+    };
+
+    private static ReturnShipment MapReturnShipment(ReturnShipmentReply s) => new()
+    {
+        Id = s.Id,
+        ReturnRequestId = s.ReturnRequestId,
+        Carrier = s.Carrier,
+        TrackingNumber = s.TrackingNumber,
+        LabelUrl = s.LabelUrl,
+        Status = s.Status,
+        DropOffLocation = string.IsNullOrEmpty(s.DropOffLocation) ? null : s.DropOffLocation,
+        ShippedAt = string.IsNullOrEmpty(s.ShippedAt) ? null : s.ShippedAt,
+        DeliveredAt = string.IsNullOrEmpty(s.DeliveredAt) ? null : s.DeliveredAt,
+        CreatedAt = s.CreatedAt
     };
 
     private static ReturnRequest MapReturn(ReturnReply r) => new()

--- a/graphql-api/GraphQL.Api/Types/ReturnType.cs
+++ b/graphql-api/GraphQL.Api/Types/ReturnType.cs
@@ -24,3 +24,17 @@ public class ReturnRequest
     public string? ExchangeProductName { get; set; }
     public string? ExchangeOrderId { get; set; }
 }
+
+public class ReturnShipment
+{
+    public long Id { get; set; }
+    public long ReturnRequestId { get; set; }
+    public string Carrier { get; set; } = default!;
+    public string TrackingNumber { get; set; } = default!;
+    public string LabelUrl { get; set; } = default!;
+    public string Status { get; set; } = default!;
+    public string? DropOffLocation { get; set; }
+    public string? ShippedAt { get; set; }
+    public string? DeliveredAt { get; set; }
+    public string CreatedAt { get; set; } = default!;
+}

--- a/return-service/Return.Application/Carriers/ICarrierAdapter.cs
+++ b/return-service/Return.Application/Carriers/ICarrierAdapter.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Return.Application.Carriers
+{
+    public class ShippingLabel
+    {
+        public string TrackingNumber { get; set; } = string.Empty;
+        public string LabelUrl { get; set; } = string.Empty;
+        public string Carrier { get; set; } = string.Empty;
+    }
+
+    public class ShipmentStatus
+    {
+        public string TrackingNumber { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+    }
+
+    public interface ICarrierAdapter
+    {
+        Task<ShippingLabel> GenerateReturnLabelAsync(string rmaNumber, string carrier, CancellationToken cancellationToken = default);
+        Task<ShipmentStatus> GetShipmentStatusAsync(string trackingNumber, string carrier, CancellationToken cancellationToken = default);
+    }
+}

--- a/return-service/Return.Application/Carriers/StubCarrierAdapter.cs
+++ b/return-service/Return.Application/Carriers/StubCarrierAdapter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Return.Application.Carriers
+{
+    public class StubCarrierAdapter : ICarrierAdapter
+    {
+        public Task<ShippingLabel> GenerateReturnLabelAsync(string rmaNumber, string carrier, CancellationToken cancellationToken = default)
+        {
+            var trackingNumber = $"{carrier.ToUpper()}-RTN-{Guid.NewGuid().ToString()[..8].ToUpper()}";
+
+            return Task.FromResult(new ShippingLabel
+            {
+                TrackingNumber = trackingNumber,
+                LabelUrl = $"https://labels.example.com/{carrier}/{trackingNumber}.pdf",
+                Carrier = carrier
+            });
+        }
+
+        public Task<ShipmentStatus> GetShipmentStatusAsync(string trackingNumber, string carrier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ShipmentStatus
+            {
+                TrackingNumber = trackingNumber,
+                Status = "InTransit",
+                Location = "Distribution Center"
+            });
+        }
+    }
+}

--- a/return-service/Return.Application/Commands/GenerateReturnLabelCommand.cs
+++ b/return-service/Return.Application/Commands/GenerateReturnLabelCommand.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Ecommerce.Model.Return.Response;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Return.Application.Carriers;
+using Return.Application.Entities;
+
+namespace Return.Application.Commands
+{
+    public class GenerateReturnLabelCommand : IRequest<ReturnShipmentResponse>
+    {
+        public long ReturnRequestId { get; set; }
+        public string Carrier { get; set; } = "royal_mail";
+    }
+
+    public class GenerateReturnLabelCommandHandler : IRequestHandler<GenerateReturnLabelCommand, ReturnShipmentResponse>
+    {
+        private readonly ReturnDbContext _dbContext;
+        private readonly ICarrierAdapter _carrierAdapter;
+        private readonly IMapper _mapper;
+
+        public GenerateReturnLabelCommandHandler(ReturnDbContext dbContext, ICarrierAdapter carrierAdapter, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _carrierAdapter = carrierAdapter;
+            _mapper = mapper;
+        }
+
+        public async Task<ReturnShipmentResponse> Handle(GenerateReturnLabelCommand command, CancellationToken cancellationToken)
+        {
+            var ret = await _dbContext.ReturnRequests
+                .FirstOrDefaultAsync(r => r.Id == command.ReturnRequestId, cancellationToken)
+                ?? throw new InvalidOperationException("Return request not found");
+
+            if (ret.Status != "Approved")
+                throw new InvalidOperationException($"Cannot generate label for return in status '{ret.Status}'");
+
+            var existing = await _dbContext.ReturnShipments
+                .FirstOrDefaultAsync(s => s.ReturnRequestId == command.ReturnRequestId, cancellationToken);
+
+            if (existing != null)
+                return _mapper.Map<ReturnShipmentResponse>(existing);
+
+            var label = await _carrierAdapter.GenerateReturnLabelAsync(ret.RmaNumber, command.Carrier, cancellationToken);
+
+            var shipment = new ReturnShipment
+            {
+                ReturnRequestId = ret.Id,
+                Carrier = label.Carrier,
+                TrackingNumber = label.TrackingNumber,
+                LabelUrl = label.LabelUrl,
+                Status = "LabelGenerated"
+            };
+
+            _dbContext.ReturnShipments.Add(shipment);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return _mapper.Map<ReturnShipmentResponse>(shipment);
+        }
+    }
+}

--- a/return-service/Return.Application/Commands/UpdateShipmentStatusCommand.cs
+++ b/return-service/Return.Application/Commands/UpdateShipmentStatusCommand.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Ecommerce.Model.Return.Response;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Return.Application.Carriers;
+
+namespace Return.Application.Commands
+{
+    public class UpdateShipmentStatusCommand : IRequest<ReturnShipmentResponse>
+    {
+        public long ReturnRequestId { get; set; }
+    }
+
+    public class UpdateShipmentStatusCommandHandler : IRequestHandler<UpdateShipmentStatusCommand, ReturnShipmentResponse>
+    {
+        private readonly ReturnDbContext _dbContext;
+        private readonly ICarrierAdapter _carrierAdapter;
+        private readonly IMapper _mapper;
+
+        public UpdateShipmentStatusCommandHandler(ReturnDbContext dbContext, ICarrierAdapter carrierAdapter, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _carrierAdapter = carrierAdapter;
+            _mapper = mapper;
+        }
+
+        public async Task<ReturnShipmentResponse> Handle(UpdateShipmentStatusCommand command, CancellationToken cancellationToken)
+        {
+            var shipment = await _dbContext.ReturnShipments
+                .FirstOrDefaultAsync(s => s.ReturnRequestId == command.ReturnRequestId, cancellationToken)
+                ?? throw new InvalidOperationException("Return shipment not found");
+
+            var status = await _carrierAdapter.GetShipmentStatusAsync(shipment.TrackingNumber, shipment.Carrier, cancellationToken);
+
+            shipment.Status = status.Status;
+            shipment.UpdatedAt = DateTime.UtcNow;
+
+            if (status.Status == "Delivered" && shipment.DeliveredAt == null)
+            {
+                shipment.DeliveredAt = DateTime.UtcNow;
+
+                var ret = await _dbContext.ReturnRequests
+                    .FirstOrDefaultAsync(r => r.Id == shipment.ReturnRequestId, cancellationToken);
+                if (ret != null && ret.Status == "Approved")
+                {
+                    ret.Status = "Received";
+                    ret.ReceivedAt = DateTime.UtcNow;
+                    ret.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return _mapper.Map<ReturnShipmentResponse>(shipment);
+        }
+    }
+}

--- a/return-service/Return.Application/Entities/ReturnShipment.cs
+++ b/return-service/Return.Application/Entities/ReturnShipment.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Return.Application.Entities
+{
+    public class ReturnShipment
+    {
+        public long Id { get; set; }
+        public long ReturnRequestId { get; set; }
+        public string Carrier { get; set; } = string.Empty; // ups, fedex, dhl, royal_mail
+        public string TrackingNumber { get; set; } = string.Empty;
+        public string LabelUrl { get; set; } = string.Empty;
+        public string Status { get; set; } = "LabelGenerated"; // LabelGenerated, InTransit, Delivered, PickupScheduled
+        public string DropOffLocation { get; set; } = string.Empty;
+        public DateTime? ShippedAt { get; set; }
+        public DateTime? DeliveredAt { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/return-service/Return.Application/MapperProfile.cs
+++ b/return-service/Return.Application/MapperProfile.cs
@@ -9,6 +9,7 @@ namespace Return.Application
         public MapperProfile()
         {
             CreateMap<ReturnRequest, ReturnResponse>();
+            CreateMap<Entities.ReturnShipment, Ecommerce.Model.Return.Response.ReturnShipmentResponse>();
         }
     }
 }

--- a/return-service/Return.Application/Queries/GetReturnShipmentQuery.cs
+++ b/return-service/Return.Application/Queries/GetReturnShipmentQuery.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Ecommerce.Model.Return.Response;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Return.Application.Queries
+{
+    public record GetReturnShipmentQuery(long ReturnRequestId) : IRequest<ReturnShipmentResponse>;
+
+    public class GetReturnShipmentQueryHandler : IRequestHandler<GetReturnShipmentQuery, ReturnShipmentResponse>
+    {
+        private readonly ReturnDbContext _dbContext;
+        private readonly IMapper _mapper;
+
+        public GetReturnShipmentQueryHandler(ReturnDbContext dbContext, IMapper mapper)
+        {
+            _dbContext = dbContext;
+            _mapper = mapper;
+        }
+
+        public async Task<ReturnShipmentResponse> Handle(GetReturnShipmentQuery request, CancellationToken cancellationToken)
+        {
+            var shipment = await _dbContext.ReturnShipments
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.ReturnRequestId == request.ReturnRequestId, cancellationToken);
+
+            return shipment == null ? null : _mapper.Map<ReturnShipmentResponse>(shipment);
+        }
+    }
+}

--- a/return-service/Return.Application/ReturnDbContext.cs
+++ b/return-service/Return.Application/ReturnDbContext.cs
@@ -11,6 +11,7 @@ namespace Return.Application
         }
 
         public DbSet<ReturnRequest> ReturnRequests { get; set; }
+        public DbSet<ReturnShipment> ReturnShipments { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -35,6 +36,19 @@ namespace Return.Application
                 entity.HasIndex(e => e.CustomerId);
                 entity.Property(e => e.ExchangeProductName).HasMaxLength(200);
                 entity.HasIndex(e => e.ExchangeOrderId);
+            });
+
+            modelBuilder.Entity<ReturnShipment>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
+                entity.HasIndex(e => e.ReturnRequestId).IsUnique();
+                entity.HasIndex(e => e.TrackingNumber).IsUnique();
+                entity.Property(e => e.Carrier).HasMaxLength(50).IsRequired();
+                entity.Property(e => e.TrackingNumber).HasMaxLength(100).IsRequired();
+                entity.Property(e => e.LabelUrl).HasMaxLength(500).IsRequired();
+                entity.Property(e => e.Status).HasMaxLength(30).IsRequired();
+                entity.Property(e => e.DropOffLocation).HasMaxLength(500);
             });
         }
     }

--- a/return-service/Return.Infrastructure/Migrations/20260409222312_AddReturnShipments.Designer.cs
+++ b/return-service/Return.Infrastructure/Migrations/20260409222312_AddReturnShipments.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Return.Application;
@@ -11,9 +12,11 @@ using Return.Application;
 namespace Return.Infrastructure.Migrations
 {
     [DbContext(typeof(ReturnDbContext))]
-    partial class ReturnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409222312_AddReturnShipments")]
+    partial class AddReturnShipments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/return-service/Return.Infrastructure/Migrations/20260409222312_AddReturnShipments.cs
+++ b/return-service/Return.Infrastructure/Migrations/20260409222312_AddReturnShipments.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Return.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReturnShipments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReturnShipments",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ReturnRequestId = table.Column<long>(type: "bigint", nullable: false),
+                    Carrier = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    TrackingNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LabelUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Status = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    DropOffLocation = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    ShippedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeliveredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReturnShipments", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReturnShipments_ReturnRequestId",
+                table: "ReturnShipments",
+                column: "ReturnRequestId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReturnShipments_TrackingNumber",
+                table: "ReturnShipments",
+                column: "TrackingNumber",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReturnShipments");
+        }
+    }
+}

--- a/return-service/Return.Service/Program.cs
+++ b/return-service/Return.Service/Program.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Return.Application;
+using Return.Application.Carriers;
 using Return.Application.Commands;
 using Return.Infrastructure;
 using Return.Service.Services;
@@ -39,6 +40,7 @@ try
     builder.Services.AddValidatorsFromAssembly(typeof(CreateReturnCommand).Assembly);
     builder.Services.AddAutoMapper(cfg => { }, typeof(Return.Application.MapperProfile).Assembly);
 
+    builder.Services.AddSingleton<ICarrierAdapter, StubCarrierAdapter>();
     builder.Services.AddOrderGrpcClient(builder.Configuration);
     builder.Services.AddProductGrpcClient(builder.Configuration);
 

--- a/return-service/Return.Service/Services/ReturnsGrpcService.cs
+++ b/return-service/Return.Service/Services/ReturnsGrpcService.cs
@@ -91,6 +91,35 @@ public class ReturnsGrpcService : ReturnsGrpc.ReturnsGrpcBase
         return MapToReply(result);
     }
 
+    public override async Task<ReturnShipmentReply> GenerateReturnLabel(GenerateReturnLabelRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GenerateReturnLabelCommand
+        {
+            ReturnRequestId = request.ReturnRequestId,
+            Carrier = string.IsNullOrEmpty(request.Carrier) ? "royal_mail" : request.Carrier
+        }, context.CancellationToken);
+
+        return MapToShipmentReply(result);
+    }
+
+    public override async Task<ReturnShipmentReply> GetReturnShipment(GetReturnShipmentRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new GetReturnShipmentQuery(request.ReturnRequestId), context.CancellationToken);
+        if (result == null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Shipment for return {request.ReturnRequestId} not found"));
+        return MapToShipmentReply(result);
+    }
+
+    public override async Task<ReturnShipmentReply> UpdateShipmentStatus(UpdateShipmentStatusRequest request, ServerCallContext context)
+    {
+        var result = await _mediator.Send(new UpdateShipmentStatusCommand
+        {
+            ReturnRequestId = request.ReturnRequestId
+        }, context.CancellationToken);
+
+        return MapToShipmentReply(result);
+    }
+
     private static ReturnReply MapToReply(ReturnResponse r) => new()
     {
         Id = r.Id,
@@ -114,5 +143,19 @@ public class ReturnsGrpcService : ReturnsGrpc.ReturnsGrpcBase
         ExchangeProductId = r.ExchangeProductId ?? 0,
         ExchangeProductName = r.ExchangeProductName ?? string.Empty,
         ExchangeOrderId = r.ExchangeOrderId?.ToString() ?? string.Empty
+    };
+
+    private static ReturnShipmentReply MapToShipmentReply(ReturnShipmentResponse s) => new()
+    {
+        Id = s.Id,
+        ReturnRequestId = s.ReturnRequestId,
+        Carrier = s.Carrier,
+        TrackingNumber = s.TrackingNumber,
+        LabelUrl = s.LabelUrl,
+        Status = s.Status,
+        DropOffLocation = s.DropOffLocation ?? string.Empty,
+        ShippedAt = s.ShippedAt?.ToString("O") ?? string.Empty,
+        DeliveredAt = s.DeliveredAt?.ToString("O") ?? string.Empty,
+        CreatedAt = s.CreatedAt.ToString("O")
     };
 }

--- a/shared/Ecommerce.Shared.Protos/Protos/returns.proto
+++ b/shared/Ecommerce.Shared.Protos/Protos/returns.proto
@@ -12,6 +12,9 @@ service ReturnsGrpc {
   rpc ApproveReturn (ApproveReturnGrpcRequest) returns (ReturnReply);
   rpc RejectReturn (RejectReturnGrpcRequest) returns (ReturnReply);
   rpc ResolveReturn (ResolveReturnGrpcRequest) returns (ReturnReply);
+  rpc GenerateReturnLabel (GenerateReturnLabelRequest) returns (ReturnShipmentReply);
+  rpc GetReturnShipment (GetReturnShipmentRequest) returns (ReturnShipmentReply);
+  rpc UpdateShipmentStatus (UpdateShipmentStatusRequest) returns (ReturnShipmentReply);
 }
 
 message GetReturnRequest {
@@ -83,4 +86,30 @@ message ResolveReturnGrpcRequest {
   string refund_amount = 3;
   int64 exchange_product_id = 4;
   string exchange_product_name = 5;
+}
+
+message GenerateReturnLabelRequest {
+  int64 return_request_id = 1;
+  string carrier = 2;
+}
+
+message GetReturnShipmentRequest {
+  int64 return_request_id = 1;
+}
+
+message UpdateShipmentStatusRequest {
+  int64 return_request_id = 1;
+}
+
+message ReturnShipmentReply {
+  int64 id = 1;
+  int64 return_request_id = 2;
+  string carrier = 3;
+  string tracking_number = 4;
+  string label_url = 5;
+  string status = 6;
+  string drop_off_location = 7;
+  string shipped_at = 8;
+  string delivered_at = 9;
+  string created_at = 10;
 }


### PR DESCRIPTION
## Summary
- Adds ReturnShipment entity with carrier adapter abstraction (`ICarrierAdapter`)
- Stub carrier implementation generates tracking numbers and label URLs (swappable for real carrier APIs like UPS/FedEx/DHL)
- Auto-marks return as "Received" when carrier reports shipment delivered
- 3 new gRPC endpoints: GenerateReturnLabel, GetReturnShipment, UpdateShipmentStatus
- GraphQL query and mutations for label generation and tracking
- EF Core migration for ReturnShipments table

Closes #139

## Test plan
- [x] Full solution builds with 0 errors
- [x] All existing unit tests pass (no regressions)
- [ ] Generate a return label for an approved return via GraphQL
- [ ] Verify idempotent label generation (second call returns existing)
- [ ] Test shipment status update flow
- [ ] Verify return auto-transitions to "Received" on delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)